### PR TITLE
add displayName & add to backendTesting page

### DIFF
--- a/src/pages/BackendTesting.tsx
+++ b/src/pages/BackendTesting.tsx
@@ -10,9 +10,10 @@ const BackendTesting = ({ setCurrentPage }: { setCurrentPage: (arg0: Page) => vo
   const [email, onChangeEmail] = React.useState("email");
   const [username, onChangeUsername] = React.useState("username");
   const [password, onChangePassword] = React.useState("password");
+  const [displayName, onChangeDisplayName] = React.useState("displayName");
 
   async function makeUser() {
-    await createUser(email, password, username);
+    await createUser(email, password, username, displayName);
     console.log("done")
     console.log(await getCurrentUser())
   }
@@ -27,6 +28,7 @@ const BackendTesting = ({ setCurrentPage }: { setCurrentPage: (arg0: Page) => vo
   const _onChangeEmail = (evt: { target: { value: React.SetStateAction<string>; }; }) => { onChangeEmail(evt.target.value) }
   const _onChangeUsername = (evt: { target: { value: React.SetStateAction<string>; }; }) => { onChangeUsername(evt.target.value) }
   const _onChangePassword = (evt: { target: { value: React.SetStateAction<string>; }; }) => { onChangePassword(evt.target.value) }
+  const _onChangeDisplayName = (evt: { target: { value: React.SetStateAction<string>; }; }) => { onChangeDisplayName(evt.target.value) }
 
   return (
     <div className="App">
@@ -35,6 +37,7 @@ const BackendTesting = ({ setCurrentPage }: { setCurrentPage: (arg0: Page) => vo
         <input type="text" value={email} onChange={_onChangeEmail} />
         <input type="text" value={username} onChange={_onChangeUsername} />
         <input type="text" value={password} onChange={_onChangePassword} />
+        <input type="text" value={displayName} onChange={_onChangeDisplayName} />
         <button onClick={makeUser}>Make a user  </button>
         <button onClick={signin}>Sign in </button>
         <button onClick={sendAuthEmail}>Send the email  </button>


### PR DESCRIPTION
## Describe your changes
Users will now have a display name that is required but mutable, unlike their username/handle. 

Added support for this on our backend testing localhost page:
![image](https://user-images.githubusercontent.com/73561858/205181935-212a35c4-93ad-4acd-83b7-4c9f2c50324d.png)

Example of a displayName in our db:
![image](https://user-images.githubusercontent.com/73561858/205181824-fb22229e-6585-4a0e-b6a8-01b171a8bfad.png)

----
I still don't fully understand submodules, and based on the changed files below I'm not sure if I did it correctly. Might need to call and discuss if it's messed up.

## Issue ticket number and link
[Add full name field to User object#12](https://github.com/ucf-tower-app/xplat/issues/12)

## Checklist before requesting a review
- [x] All code is linted and conforms to style guide
- [x] All necessary context is described in the PR or Issue
- [x] This branch is code and feature complete. If it is not complete, this PR is a draft.
