### PR TITLE
Cursor migrations

### DIFF
--- a/src/components/PostDetails.tsx
+++ b/src/components/PostDetails.tsx
@@ -1,29 +1,37 @@
 import { Box, Text } from 'native-base';
 import { Post } from '../xplat/types/post';
-import { useState, useEffect} from 'react';
+import { useState, useEffect } from 'react';
 import { Comment } from '../xplat/types/comment';
 import CommentDisplay from './PostDetailsComment';
 
-const PostDetails = ({post}: {post: Post | undefined}) => {
+const PostDetails = ({ post }: { post: Post | undefined }) => {
     const [comments, setComments] = useState<Comment[] | undefined>();
 
-    useEffect( () => {
-        post?.getComments().then( (data) => setComments(data));
+    useEffect(() => {
+        const fetchComments = async () => {
+            const commentsCursor = post?.getCommentsCursor();
+            const tempComments: Comment[] = [];
+            while ((await commentsCursor?.hasNext)) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                tempComments.push((await commentsCursor?.pollNext())!);
+            }
+            setComments(tempComments);
+        };
+        fetchComments();
     }, [post]);
-
 
     return (
         <Box flexDir={'column'} margin={2} position='fixed' width={'22%'}>
-            {post !== undefined ? 
+            {post !== undefined ?
                 <Box>
                     <Text alignSelf={'center'}>Comments</Text>
-                    {comments === undefined || comments!.length === 0 ? 
-                        <Box marginTop={2}><Text alignSelf={'center'}>No comments just yet.</Text></Box> 
+                    {comments === undefined || comments!.length === 0 ?
+                        <Box marginTop={2}><Text alignSelf={'center'}>No comments just yet.</Text></Box>
                         :
-                        comments?.map( (value, index) => {
+                        comments?.map((value, index) => {
                             return (
                                 <Box key={index} margin={2}>
-                                    <CommentDisplay comment={value}/>
+                                    <CommentDisplay comment={value} />
                                 </Box>
                             );
                         })
@@ -31,7 +39,7 @@ const PostDetails = ({post}: {post: Post | undefined}) => {
                 </Box> :
                 <Box>
                     <Text alignSelf={'center'}>No post selected</Text>
-                </Box> }
+                </Box>}
         </Box>
     );
 };

--- a/src/components/RouteFeedDisplay.tsx
+++ b/src/components/RouteFeedDisplay.tsx
@@ -1,26 +1,39 @@
-import {Box, Text, Pressable} from 'native-base';
+import { Box, Pressable } from 'native-base';
 import { Forum } from '../xplat/types/forum';
 import { Post } from '../xplat/types/post';
-import { useState, useEffect} from 'react';
+import { useState, useEffect } from 'react';
 import PostInFeed from './PostInFeed';
 
 type callBackFunction = (post: Post) => void;
 
-const RouteFeedDisplay = ({forum, setPostInParent}: {forum: Forum | undefined, setPostInParent: callBackFunction},) => {
+const RouteFeedDisplay = ({
+    forum,
+    setPostInParent,
+}: {
+  forum: Forum | undefined;
+  setPostInParent: callBackFunction;
+}) => {
     const [posts, setPosts] = useState<Post[]>();
-    
+
     useEffect(() => {
-        forum?.getPosts().then((data) => {
-            setPosts(data);
-        });
+        const fetchPosts = async () => {
+            const postCursor = forum?.getPostsCursor();
+            const tempPosts: Post[] = [];
+            while((await postCursor?.hasNext())){
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                tempPosts.push((await postCursor?.pollNext())!);
+            }
+            setPosts(tempPosts);
+        };
+        fetchPosts();
     }, [forum]);
 
     return (
         <Box zIndex={10} width={'75%'}>
-            {posts?.map( (value, index) => {
+            {posts?.map((value, index) => {
                 return (
                     <Pressable onPress={() => setPostInParent(value)} key={index}>
-                        <PostInFeed post={value}/>
+                        <PostInFeed post={value} />
                     </Pressable>
                 );
             })}

--- a/src/components/backend/ForumDisplay.tsx
+++ b/src/components/backend/ForumDisplay.tsx
@@ -2,18 +2,29 @@ import { useEffect, useState } from 'react';
 import { Forum, Post } from '../../xplat/types/types';
 import PostDisplay from './PostDisplay';
 
-const ForumDisplay = ({forum}: {forum: Forum}) => {
-    const [posts, setPosts] = useState<Post[]>([]);
-    
-    useEffect(() => {forum.getPosts().then((_posts) => setPosts(_posts));}, [forum]);
+const ForumDisplay = ({ forum }: { forum: Forum }) => {
+    const [posts] = useState<Post[]>([]);
+
+    useEffect(() => {
+        const fetchPosts = async () => {
+            const postCursor = forum.getPostsCursor();
+            const tempPosts: Post[] = [];
+            while (await postCursor.hasNext()) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                tempPosts.push((await postCursor.pollNext())!);
+            }
+        };
+        fetchPosts();
+    }, [forum]);
 
     return (
         <ul className="forumElement">
-            {posts.map(function(d, idx){
+            {posts.map(function (d, idx) {
                 return (
                     <li key={idx}>
-                        <PostDisplay post={d}/>      
-                    </li>);
+                        <PostDisplay post={d} />
+                    </li>
+                );
             })}
         </ul>
     );

--- a/src/components/backend/PostDisplay.tsx
+++ b/src/components/backend/PostDisplay.tsx
@@ -41,11 +41,11 @@ const PostDisplay = ({post}: {post: Post}) => {
                 <source src={videoUrl} type="video/mp4"/>
             </video>}
             <p>- {author}</p>
-            <button onClick={() => {console.log(post);}}>Print Object</button>
-            <button onClick={() => {getCurrentUser().then((user) => post.addLike(user));}}>Like</button>
-            <button onClick={() => {getCurrentUser().then((user) => post.removeLike(user));}}>Unlike</button>
-            <button onClick={() => {getCurrentUser().then(async (user) => console.log(await post.likedBy(user)));}}>Liked?</button>
-            <button onClick={() => {post.delete();}}>Delete</button>
+            <button style={{ width:'50px' }} onClick={() => {console.log(post);}}>Print</button>
+            <button style={{ width:'40px' }} onClick={() => {getCurrentUser().then((user) => post.addLike(user));}}>Like</button>
+            <button style={{ width:'50px' }} onClick={() => {getCurrentUser().then((user) => post.removeLike(user));}}>Unlike</button>
+            <button style={{ width:'50px' }} onClick={() => {post.delete();}}>Delete</button>
+            {/* <button style={{ width:'40px' }} onClick={() => {post.editTextContent('Edited lol');}}>Edit</button> */}
             <div>{comments.map((cmt) => <CommentDisplay comment={cmt}/>)} {comments.length} comments</div>
             <input type="text" value={newCommentText} onChange={(evt) => {setNewCommentText(evt.target.value);}} />
             {/* <button onClick={async () => {

--- a/src/components/backend/PostDisplay.tsx
+++ b/src/components/backend/PostDisplay.tsx
@@ -8,22 +8,27 @@ import { Comment, Post } from '../../xplat/types/types';
 import CommentDisplay from './CommentDisplay';
 
 
-const PostDisplay = ({post}: {post: Post}) => {
+const PostDisplay = ({ post }: { post: Post }) => {
     const [author, setAuthor] = useState('!!!');
     const [textContent, setTextContent] = useState('!!!');
     const [imageUrls, setImageUrls] = useState<string[] | undefined>(undefined);
     const [comments, setComments] = useState<Comment[]>([]);
     const [newCommentText, setNewCommentText] = useState<string>('nice send');
-    const [thumbnailUrl, setThumbnailUrl] = useState<string| undefined>(undefined);
-    const [videoUrl, setVideoUrl] = useState<string| undefined>(undefined);
-    
+    const [thumbnailUrl] = useState<string | undefined>(undefined);
+    const [videoUrl] = useState<string | undefined>(undefined);
+
     useEffect(() => {
         async function fetch() {
             await post.getData();
             post.getTextContent().then(setTextContent);
-            post.getAuthor().then((author) => {author.getUsername().then(setAuthor);});
+            post.getAuthor().then((author) => { author.getUsername().then(setAuthor); });
             post.getImageContentUrls().then(setImageUrls);
-            post.getComments().then(setComments);
+            const commentsCursor = post.getCommentsCursor();
+            const tempComments: Comment[] = [];
+            while (await commentsCursor.hasNext()) {
+                tempComments.push((await commentsCursor.pollNext())!);
+            }
+            setComments(tempComments);
             // post.hasVideoContent().then(async (b) => {if(b) {
             //     post.getVideoThumbnailUrl().then(setThumbnailUrl);
             //     post.getVideoUrl().then(setVideoUrl);
@@ -35,19 +40,19 @@ const PostDisplay = ({post}: {post: Post}) => {
     return (
         <div className="hbox">
             <p>"{textContent}"</p>
-            {imageUrls && <div>{imageUrls!.map((url) => <img src={url} className="fillHeight" style={{ width: 45, height: 45 }} alt=""/>)}</div>}
-            {thumbnailUrl && <img src={thumbnailUrl} className="fillHeight" style={{ width: 45, height: 45 }} alt=""/>}
+            {imageUrls && <div>{imageUrls!.map((url) => <img src={url} className="fillHeight" style={{ width: 45, height: 45 }} alt="" />)}</div>}
+            {thumbnailUrl && <img src={thumbnailUrl} className="fillHeight" style={{ width: 45, height: 45 }} alt="" />}
             {videoUrl && <video width="150" height="100" controls >
-                <source src={videoUrl} type="video/mp4"/>
+                <source src={videoUrl} type="video/mp4" />
             </video>}
             <p>- {author}</p>
-            <button style={{ width:'50px' }} onClick={() => {console.log(post);}}>Print</button>
-            <button style={{ width:'40px' }} onClick={() => {getCurrentUser().then((user) => post.addLike(user));}}>Like</button>
-            <button style={{ width:'50px' }} onClick={() => {getCurrentUser().then((user) => post.removeLike(user));}}>Unlike</button>
-            <button style={{ width:'50px' }} onClick={() => {post.delete();}}>Delete</button>
+            <button style={{ width: '50px' }} onClick={() => { console.log(post); }}>Print</button>
+            <button style={{ width: '40px' }} onClick={() => { getCurrentUser().then((user) => post.addLike(user)); }}>Like</button>
+            <button style={{ width: '50px' }} onClick={() => { getCurrentUser().then((user) => post.removeLike(user)); }}>Unlike</button>
+            <button style={{ width: '50px' }} onClick={() => { post.delete(); }}>Delete</button>
             {/* <button style={{ width:'40px' }} onClick={() => {post.editTextContent('Edited lol');}}>Edit</button> */}
-            <div>{comments.map((cmt) => <CommentDisplay comment={cmt}/>)} {comments.length} comments</div>
-            <input type="text" value={newCommentText} onChange={(evt) => {setNewCommentText(evt.target.value);}} />
+            <div>{comments.map((cmt) => <CommentDisplay comment={cmt} />)} {comments.length} comments</div>
+            <input type="text" value={newCommentText} onChange={(evt) => { setNewCommentText(evt.target.value); }} />
             {/* <button onClick={async () => {
                 await post.addComment(await getCurrentUser(), newCommentText);
                 console.log('Commented');

--- a/src/components/backend/RouteDisplay.tsx
+++ b/src/components/backend/RouteDisplay.tsx
@@ -7,24 +7,32 @@ const RouteDisplay = ({route}: {route: Route}) => {
     const [routeDiff, setRouteDiff] = useState('!!!');
     const [routeSetter, setRouteSetter] = useState('!!!');
     const [forum, setForum] = useState<Forum | undefined>(undefined);
+    const [thumbnail, setThumbnail] = useState<string | undefined>(undefined);
     
-    useEffect(() => {route.getName().then((name) => setRouteName(name));}, [route]);
-    useEffect(() => {route.getRating().then((grade) => setRouteDiff(grade));}, [route]);
     useEffect(() => {
-        route.getSetter().then(async (setter) => {
-            if(setter !== undefined) 
-                setRouteSetter(await setter.getUsername());
-        });
-    }, [route]);
-    useEffect(() => {route.getForum().then((_forum) => setForum(_forum));}, [route]);
+        const run = async () => {
+            await route.getData();
+            route.getName().then(setRouteName);
+            // route.getGradeDisplayString().then(setRouteDiff);
+            // route.hasThumbnail().then(async (yeah) => yeah ? route.getThumbnailUrl().then(setThumbnail) : undefined);
+            route.getSetter().then(async (setter) => {
+                if(setter !== undefined) 
+                    setRouteSetter(await setter.getUsername());
+            });
+            route.getForum().then(setForum);
+        };
+        run();
+    });
     
     
     return (
         <div>
             <div className="hbox">
                 <p>{routeName}</p>
+                {thumbnail && <img src={thumbnail} className="fillHeight" style={{ width: 45, height: 45 }} alt=""/>}
                 <p>{routeDiff}</p>
                 {routeSetter !== '!!!' ? <p>{routeSetter}</p> : <div/>}
+                <button onClick={() => console.log(route)}>Print Route</button>
             </div>
             {forum && <ForumDisplay forum={forum!}/>}
         </div>

--- a/src/pages/BackendTesting.tsx
+++ b/src/pages/BackendTesting.tsx
@@ -1,25 +1,56 @@
 /* eslint-disable max-len */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import '../App.css';
 import logo from '../logo.svg';
 
 import RouteDisplay from '../components/backend/RouteDisplay';
-import { createPost, createRoute, createUser, getCurrentUser, getRouteById, getUrl, getUserByUsername, sendAuthEmail, signIn } from '../xplat/api';
+import { createPost, createUser, getActiveRoutesCursor, getAllPostsCursor, getAllRoutesCursor, getAllTopropeRouteClassifiers, getCurrentUser, getRouteById, getSendById, getUserByUsername, sendAuthEmail, signIn } from '../xplat/api';
+import { getTestMergePostsCursor } from '../xplat/types/queryCursors';
 
 const BackendTesting = () => {
     const [email, onChangeEmail] = useState('lkf53414@xcoxc.com');
     const [username, onChangeUsername] = useState('BinLiftingSux');
     const [password, onChangePassword] = useState('password');
-    const [imgSrc, setImgSrc] = useState(logo);
+    const [imgSrc] = useState(logo);
     const [targUsername, setTargUsername] = useState('CringePotato49');
-    const [route, setRoute] = useState(getRouteById('GQBdclAMmE2v4nDPphsc'));
+    const [route, setRoute] = useState(getRouteById('98sSTIj8FVYUaFGTQOR1'));
     const [routeName, setRouteName] = useState('New Route');
-    const [routeGrade, setRouteGrade] = useState('5.9');
+    const [routeGrade, setRouteGrade] = useState(3);
+    const [routeType, setRouteType] = useState('Boulder');
+    const [routeDescription, setRouteDescription] = useState('description');
+    const [rope, setRope] = useState(-1);
+    const [routeThumbnail, setRouteThumbnail] = useState<Blob | undefined>();
     const [routeSetterUsername, setRouteSetterUsername] = useState('No Setter');
     const [postText, setPostText] = useState('Hello there!');
     const [postImages, setPostImages] = useState<Blob[] | undefined>();
     const [postVideoThumbnail, setPostVideoThumbnail] = useState<Blob | undefined>(undefined);
     const [postVideo, setPostVideo] = useState<Blob | undefined>(undefined);
+    const [allRoutesCursor] = useState(getAllRoutesCursor());
+    const [activeRoutesCursor] = useState(getActiveRoutesCursor());
+    const [postsCursor] = useState(getAllPostsCursor());
+    const [mergeCursor] = useState(getTestMergePostsCursor());
+
+    useEffect(() => {
+        const go = async () => {
+            console.log('shrt'.match('^[a-z]{5,15}$'));
+            console.log('goldilocks'.match('^[a-z]{5,15}$'));
+            console.log('waaaaaaaaaaaytoolong'.match('^[a-z]{5,15}$'));
+            console.log('Uppercase'.match('^[a-z]{5,15}$'));
+            console.log('Symbo$^ls!'.match('^[a-z]{5,15}$'));
+            console.log('Sp aa ces'.match('^[a-z]{5,15}$'));
+            console.log('trailspace '.match('^[a-z]{5,15}$'));
+
+
+            const send = getSendById('p5PZ9j3JaH7Ry9dDYVWv');
+            await send.getData();
+            console.log(send);
+            const prom = Promise.resolve('gaming');
+            console.log(prom);
+            console.log(getAllTopropeRouteClassifiers().map((c) => c.displayString));
+        // console.log(getAllRouteClassifiers());
+        };
+        go();
+    }, []);
 
     async function makeUser() {
         const cur = await createUser(email, password, username, 'Display Name');
@@ -55,14 +86,15 @@ const BackendTesting = () => {
         console.log(guy);
     }
 
-    async function getURL() {
-        setImgSrc(await getUrl('avatars/climber.png'));
-    }
-
     async function testCreateRoute() {
-        if (routeSetterUsername === 'No Setter')
-            await setRoute(await createRoute(routeName, routeGrade));
-        else await setRoute(await createRoute(routeName, routeGrade, await getUserByUsername(routeSetterUsername)));
+        // await setRoute(
+        //     await createRoute({
+        //         name: routeName, 
+        //         classifier: new RouteClassifier(routeGrade, routeType as RouteType),
+        //         ...(rope != -1 && {rope: rope}),
+        //         ...(routeThumbnail && {thumbnail: routeThumbnail}),
+        //         ...(routeSetterUsername && {setter: await getUserByUsername(routeSetterUsername) })
+        //     }));
         console.log(route);
     }
 
@@ -72,7 +104,7 @@ const BackendTesting = () => {
             postText, 
             await route.getForum(), 
             postImages, 
-            // postVideo && postVideoThumbnail && {video: postVideo!, thumbnail: postVideoThumbnail!}
+            postVideo && postVideoThumbnail && {video: postVideo!, thumbnail: postVideoThumbnail!}
         );
         await post.getData();
         setRoute(route);
@@ -90,15 +122,20 @@ const BackendTesting = () => {
     };
 
     const deleteUser = async () => {
-    // const del = (await getCurrentUser()).delete(password);
-    // console.log(del)
-    // await del;
-    // console.log("It is done.")
+        const del = (await getCurrentUser()).delete(password);
+        console.log(del);
+        await del;
+        console.log('It is done.');
     };
 
-    const testGetRoutes = async () => {
-    // console.log(await getActiveRoutes())
-    // console.log(await getAllRoutes())
+    const testGetAllPosts = async () => {
+        const post = await postsCursor.pollNext();
+        console.log(post);
+    };
+
+    const testGetMergePosts = async () => {
+        const post = await mergeCursor.pollNext();
+        console.log(post);
     };
 
 
@@ -125,14 +162,22 @@ const BackendTesting = () => {
                     <button onClick={testGet}>Get</button>
                     <button onClick={testFollow}>Follow</button>
                 </div>
-                <button onClick={getURL}>Get the URL </button>
+                {/* <div className='hbox'>
+                    <button onClick={testGetAllPosts}>Get next post </button>
+                    <button onClick={testGetMergePosts}>Get next merge post </button>
+                    <button onClick={() => console.log(mergeCursor)}>Print merger </button>
+                </div> */}
                 <div className='hbox'>
-                    <input type="text" value={routeName} onChange={(evt) => {setRouteName(evt.target.value);}} />
-                    <input type="text" value={routeGrade} onChange={(evt) => {setRouteGrade(evt.target.value);}} />
-                    <input type="text" value={routeSetterUsername} onChange={(evt) => {setRouteSetterUsername(evt.target.value);}} />
+                    <input style={{ width:'90px' }} type="text" value={routeName} onChange={(evt) => {setRouteName(evt.target.value);}} />
+                    <input style={{ width:'90px' }} type="text" value={routeGrade} onChange={(evt) => {setRouteGrade(parseInt(evt.target.value));}} />
+                    <input style={{ width:'90px' }} type="text" value={routeType} onChange={(evt) => {setRouteType(evt.target.value);}} />
+                    <input style={{ width:'90px' }} type="text" value={rope} onChange={(evt) => {setRope(parseInt(evt.target.value));}} />
+                    <input onChange={(evt) => {setRouteThumbnail(evt.target.files![0]);}} type="file" accept="image/*" />
+                    <input style={{ width:'90px' }} type="text" value={routeSetterUsername} onChange={(evt) => {setRouteSetterUsername(evt.target.value);}} />
         
                     <button onClick={testCreateRoute}>Create route</button>
-                    <button onClick={testGetRoutes}>Get Routes</button>
+                    <button onClick={async () => {console.log(await activeRoutesCursor.pollNext());}}>Get Active Route</button>
+                    <button onClick={async () => {console.log(await allRoutesCursor.pollNext());}}>Get All Route</button>
 
                 </div>
                 <RouteDisplay route={route}/>
@@ -154,5 +199,22 @@ const BackendTesting = () => {
         </div>
     );
 };
+
+// const BackendTesting = () => {
+//     const [postsCursor, _] = useState(getAllPostsCursor());
+
+//     const testGetAllPosts = async () => {
+//         const post = await postsCursor.pollNext();
+//         console.log(post);
+//     };
+
+
+//     return (
+//         <div className="App">
+//             <header className="App-header">
+//                 <button onClick={testGetAllPosts}>Get next post </button>
+//             </header>
+//         </div>);
+// };
 
 export default BackendTesting;


### PR DESCRIPTION
# Describe your changes
Fixed calls to getPosts() and getComments() (these functions were removed on backend) to use QueryCursor. Some of these instances of these calls might need to be switched to using a cursor (for instance, RouteFeedDisplay might want to cursor through the list of posts of a route). Also includes linting formatting changes.
![image](https://user-images.githubusercontent.com/31013771/214966055-8e9771d6-6927-4538-bbd0-9d1d541eefda.png)


# Issue ticket number and link
#39 