### PR TITLE
Implement Comment Scrolling on posts

### DIFF
--- a/src/components/NativeBaseStyling.tsx
+++ b/src/components/NativeBaseStyling.tsx
@@ -86,12 +86,14 @@ const theme = extendTheme({
         displayname: {
           fontSize: 'md',
           color: 'black',
+          noOfLines: 1,
           justifyContent: 'center',
           alignSelf: 'center',
         },
         handle: {
           color: 'gray.400',
           fontSize: 'sm',
+          noOfLines: 1,
           justifyContent: 'center',
           alignSelf: 'center',
           flex: 1

--- a/src/components/Post/Comment/CommentPanel.tsx
+++ b/src/components/Post/Comment/CommentPanel.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, Button } from 'native-base';
+import { Box, Text, Button, ScrollView } from 'native-base';
 import { Post } from '../../../xplat/types/post';
 import { useState, useEffect } from 'react';
 import { useQuery } from 'react-query';
@@ -78,16 +78,19 @@ const CommentPanel = ({ post }: { post: Post | undefined }) => {
           {comments === undefined || comments!.length === 0 ?
             <Box marginTop={2}><Text alignSelf={'center'}>No comments just yet.</Text></Box>
             :
-            comments?.map((value, index) => {
-              return (
-                <Box key={index} margin={2}>
-                  <CommentDisplay comment={value} />
-                </Box>
-              );
-            })
+            <Box position='relative' overflowY='scroll' height='80vh'>
+              {comments?.map((value, index) => {
+                return (
+                  <Box key={index} margin={2}>
+                    <CommentDisplay comment={value} />
+                  </Box>
+                );
+              })}
+            </Box>
+           
           }
           {hasMoreComments && 
-                        <Button onPress={fetchMoreComments}><Text variant='button'>Load More</Text></Button>}
+            <Button onPress={fetchMoreComments} m='1'><Text variant='button'>Load More</Text></Button>}
         </Box> :
         <Box>
           <Text alignSelf={'center'}>No post selected</Text>

--- a/src/components/Post/Comment/CommentPanel.tsx
+++ b/src/components/Post/Comment/CommentPanel.tsx
@@ -13,7 +13,7 @@ const CommentPanel = ({ post }: { post: Post | undefined }) => {
   const [comments, setComments] = useState<Comment[] | undefined>();
   const [commentsCursor, setCommentsCursor] = useState<QueryCursor<Comment>>();
   const [hasMoreComments, setHasMoreComments] = useState<boolean>(false);
-  const { isLoading, isError, data } = useQuery(['comments', post!.docRef!.id], buildCommentListFetcher(post!), 
+  const { isLoading, isError, data } = useQuery(['comments', post], buildCommentListFetcher(post!), 
     { 
       enabled: post !== undefined && post.docRef !== undefined,
     });

--- a/src/components/Post/Comment/CommentPanel.tsx
+++ b/src/components/Post/Comment/CommentPanel.tsx
@@ -13,7 +13,7 @@ const CommentPanel = ({ post }: { post: Post | undefined }) => {
   const [comments, setComments] = useState<Comment[] | undefined>();
   const [commentsCursor, setCommentsCursor] = useState<QueryCursor<Comment>>();
   const [hasMoreComments, setHasMoreComments] = useState<boolean>(false);
-  const { isLoading, isError, data } = useQuery(['comments', post], buildCommentListFetcher(post!), 
+  const { isLoading, isError, data } = useQuery(['comments', post?.docRef?.id], buildCommentListFetcher(post!), 
     { 
       enabled: post !== undefined && post.docRef !== undefined,
     });

--- a/src/components/Post/Comment/CommentPanel.tsx
+++ b/src/components/Post/Comment/CommentPanel.tsx
@@ -8,6 +8,8 @@ import { buildCommentListFetcher } from '../../../utils/queries';
 import { QueryCursor } from '../../../xplat/types/queryCursors';
 import { CURSOR_INCREMENT } from '../../../utils/constants';
 
+const PanelHeight = (document.documentElement.clientHeight * 0.8) - 50;
+
 const CommentPanel = ({ post }: { post: Post | undefined }) => {
   const [comments, setComments] = useState<Comment[] | undefined>();
   const [commentsCursor, setCommentsCursor] = useState<QueryCursor<Comment>>();
@@ -78,7 +80,7 @@ const CommentPanel = ({ post }: { post: Post | undefined }) => {
           {comments === undefined || comments!.length === 0 ?
             <Box marginTop={2}><Text alignSelf={'center'}>No comments just yet.</Text></Box>
             :
-            <Box position='relative' overflowY='scroll' height='80vh'>
+            <Box position='relative' overflowY='scroll' height={PanelHeight}>
               {comments?.map((value, index) => {
                 return (
                   <Box key={index} margin={2}>

--- a/src/components/Post/Comment/CommentPanel.tsx
+++ b/src/components/Post/Comment/CommentPanel.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, Button, ScrollView } from 'native-base';
+import { Box, Text, Button, Flex, VStack } from 'native-base';
 import { Post } from '../../../xplat/types/post';
 import { useState, useEffect } from 'react';
 import { useQuery } from 'react-query';
@@ -7,17 +7,15 @@ import CommentDisplay from './CommentDisplay';
 import { buildCommentListFetcher } from '../../../utils/queries';
 import { QueryCursor } from '../../../xplat/types/queryCursors';
 import { CURSOR_INCREMENT } from '../../../utils/constants';
-
-// Calculates panel height based on screen height, excludes NavBar height
-const PanelHeight = (document.documentElement.clientHeight - 50 ) * 0.8;
+import '../../css/feed.css';
 
 const CommentPanel = ({ post }: { post: Post | undefined }) => {
   const [comments, setComments] = useState<Comment[] | undefined>();
   const [commentsCursor, setCommentsCursor] = useState<QueryCursor<Comment>>();
   const [hasMoreComments, setHasMoreComments] = useState<boolean>(false);
-  const { isLoading, isError, data } = useQuery(['comments', post?.docRef!.id], buildCommentListFetcher(post!), 
+  const { isLoading, isError, data } = useQuery(['comments', post!.docRef!.id], buildCommentListFetcher(post!), 
     { 
-      enabled: post !== undefined 
+      enabled: post !== undefined && post.docRef !== undefined,
     });
 
   async function fetchMoreComments() {
@@ -74,27 +72,32 @@ const CommentPanel = ({ post }: { post: Post | undefined }) => {
   }
 
   return (
-    <Box flexDir={'column'} margin={2} position='fixed' width={'22%'}>
+    <Box flexDir={'column'} top='100px' position='fixed' width={'25%'} height='100%'>
       {post !== undefined ?
-        <Box>
-          <Text alignSelf={'center'}>Comments</Text>
-          {comments === undefined || comments!.length === 0 ?
+        <>
+          <Box height='25px'>
+            <Text alignSelf={'center'} bold>Comments</Text>
+          </Box>
+          {comments === undefined || comments.length === 0 ?
             <Box marginTop={2}><Text alignSelf={'center'}>No comments just yet.</Text></Box>
             :
-            <Box position='relative' overflowY='scroll' height={PanelHeight}>
-              {comments?.map((value, index) => {
-                return (
-                  <Box key={index} margin={2}>
-                    <CommentDisplay comment={value} />
-                  </Box>
-                );
-              })}
-            </Box>
-           
-          }
-          {hasMoreComments && 
-            <Button onPress={fetchMoreComments} m='1'><Text variant='button'>Load More</Text></Button>}
-        </Box> :
+            <div className='comment-panel-container'>
+              <div className='comment-panel'>
+                {comments?.map((value, index) => {
+                  return (
+                    <Box key={index} margin={1}>
+                      <CommentDisplay comment={value} />
+                    </Box>
+                  );
+                })}
+                {hasMoreComments && 
+                  <Button onPress={fetchMoreComments} m='1'>
+                    <Text variant='button'>Load More</Text>
+                  </Button>}
+              </div>
+            </div>
+          } 
+        </> :
         <Box>
           <Text alignSelf={'center'}>No post selected</Text>
         </Box>}

--- a/src/components/Post/Comment/CommentPanel.tsx
+++ b/src/components/Post/Comment/CommentPanel.tsx
@@ -8,7 +8,8 @@ import { buildCommentListFetcher } from '../../../utils/queries';
 import { QueryCursor } from '../../../xplat/types/queryCursors';
 import { CURSOR_INCREMENT } from '../../../utils/constants';
 
-const PanelHeight = (document.documentElement.clientHeight * 0.8) - 50;
+// Calculates panel height based on screen height, excludes NavBar height
+const PanelHeight = (document.documentElement.clientHeight - 50 ) * 0.8;
 
 const CommentPanel = ({ post }: { post: Post | undefined }) => {
   const [comments, setComments] = useState<Comment[] | undefined>();

--- a/src/components/css/feed.css
+++ b/src/components/css/feed.css
@@ -14,6 +14,22 @@
     border: 1px solid black;
 }
 
+.comment-panel-container {
+    width: 100%;
+    overflow: hidden;
+    height: calc(100vh - 125px);
+    justify-content: center;
+}
+
+.comment-panel {
+    width: 100%;
+    height: inherit;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    scroll-snap-align: start;   
+    padding: 0 10px;
+}
+
 .post-thumbnail {
     width: 75%;
     height: auto;


### PR DESCRIPTION
# Describe your changes
Implemented vertical overflow on CommentPanel so we can scroll to view new comments. This was easiest to do with the css `calc()` function, since it adjusts the size of a div without re-rendering the component in React.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/31017536/218141030-1d9f465d-42cc-4fba-9884-c3d235f9d7b4.png">

# Issue ticket number and link
#63 