### PR TITLE
Compress images and style components

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
     "@types/react-native": "^0.70.8",
+    "browser-image-compression": "^2.0.0",
     "native-base": "^3.4.25",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/NativeBaseStyling.tsx
+++ b/src/components/NativeBaseStyling.tsx
@@ -102,6 +102,10 @@ const theme = extendTheme({
           fontSize: 'md',
           color: 'black'
         },
+        subtext: {
+          fontSize: 'sm',
+          color: 'gray.600'
+        },
         default: {
           color: 'inherit'
         }

--- a/src/components/Route/CreateRoute.tsx
+++ b/src/components/Route/CreateRoute.tsx
@@ -146,7 +146,7 @@ const CreateRoute = ({refreshRoutes, isOpen, setIsOpen}: CreateRouteProps) => {
       <FormControl isInvalid={formError} p={1}>
         <VStack space={1} overflowY='scroll' maxH='90vh'>
           <Text fontSize='lg' alignSelf='center'>Create a new Route</Text>
-          <FormControl.Label isRequired>Route name</FormControl.Label>
+          <FormControl.Label isRequired>Route Name</FormControl.Label>
           <Input isRequired type='text' onChangeText={setName} placeholder='Name'/>
           <FormControl.Label>Route Thumbnail</FormControl.Label>
           { // if thumbnailFile is undefined, show select file input
@@ -176,11 +176,11 @@ const CreateRoute = ({refreshRoutes, isOpen, setIsOpen}: CreateRouteProps) => {
                 </HStack>
               </>
           }
-          <FormControl.Label isRequired>Route type</FormControl.Label>
+          <FormControl.Label isRequired>Route Type</FormControl.Label>
           <Select selectedValue={type} accessibilityLabel='choose route type'
             placeholder='Route type' onValueChange={ (value) => {
               const route_type = value as RouteType;
-              setRawgrade(undefined);
+              setRawgrade('');
               setModifier('');
               setType(route_type);
             }}>
@@ -188,24 +188,32 @@ const CreateRoute = ({refreshRoutes, isOpen, setIsOpen}: CreateRouteProps) => {
               return <Select.Item key={routetype} label={routetype} value={routetype}/>;
             })}
           </Select>
-          <FormControl.Label isRequired>Route grade</FormControl.Label>
-          <Select isDisabled={type === undefined} placeholder='Route grade'
-            onValueChange={ (value) => setRawgrade(value)}>
+          <FormControl.Label isRequired>Route Grade</FormControl.Label>
+          <Select isDisabled={type === undefined} placeholder='Route grade' selectedValue={rawgrade}
+            onValueChange={ (value) => {
+              setRawgrade(value);
+              setModifier('');
+            }}>
             {type !== undefined &&
               RouteTypeToGetAllClassifiers(type).map( (value) => {
                 if (value instanceof RouteClassifier)
                 {
-                  return <Select.Item value={''+value.displayString} label={value.displayString}
-                    key={value.displayString}/>;
+                  return <Select.Item value={value.displayString} label={value.displayString}
+                    key={value.rawgrade}/>;
                 }
                 
                 return <Select.Item value={value} label={value}
-                  key={value}/>;
+                  key={type + ' ' + value}/>;
               })
             }
           </Select>
           <FormControl.Label>Route Modifier</FormControl.Label>
-          <Select isDisabled={rawgrade === undefined || (type !== RouteType.Toprope && type !== RouteType.Leadclimb)} 
+          <Select selectedValue={modifier} 
+            isDisabled={
+              (rawgrade === undefined || rawgrade === '') 
+              || 
+              (type !== RouteType.Toprope && type !== RouteType.Leadclimb)
+            } 
             placeholder='Route grade modifier' onValueChange={(itemValue) => {
               setModifier(itemValue);
             }}>

--- a/src/components/css/feed.css
+++ b/src/components/css/feed.css
@@ -21,6 +21,25 @@
     justify-content: center;
 }
 
+.hidden-input {
+    display: none;
+}
+
+.native-button {
+    background-color: #0891B2;
+    color: white;
+    border: none;
+    width: fit-content;
+    padding: 10px 10px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 15px;
+    margin: 4px 2px;
+    cursor: pointer;
+    border-radius: 5px;
+}
+
 .comment-panel {
     width: 100%;
     height: inherit;

--- a/src/utils/CompressImage.ts
+++ b/src/utils/CompressImage.ts
@@ -1,0 +1,16 @@
+import imageCompression from 'browser-image-compression';
+
+const imageCompressionOptions = {
+  maxSizeMB: 1,
+  maxWidthOrHeight: 1920,
+};
+
+export const compressImage = async (image: File) => {
+  try {
+    const compressedFile = await imageCompression(image, imageCompressionOptions);
+    return compressedFile;
+  } catch (error) {
+    console.log(error);
+    return;
+  }
+};

--- a/src/utils/CompressImage.ts
+++ b/src/utils/CompressImage.ts
@@ -1,7 +1,7 @@
 import imageCompression from 'browser-image-compression';
 
 const imageCompressionOptions = {
-  maxSizeMB: 1,
+  maxSizeMB: 0.5,
   maxWidthOrHeight: 1920,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3776,6 +3776,13 @@ broadcast-channel@^3.4.1:
     rimraf "3.0.2"
     unload "2.2.0"
 
+browser-image-compression@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/browser-image-compression/-/browser-image-compression-2.0.0.tgz#f421381a76d474d4da7dcd82810daf595b09bef6"
+  integrity sha512-kBlkZo13yOOfcmrPW0M0K/UdZPogIQj2gRvXIM3FktAnfW6VRq9aY2RI+F6O0x6DMj1Xm+WLGgWcFK8Fu/ddnw==
+  dependencies:
+    uzip "0.20201231.0"
+
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz"
@@ -10058,6 +10065,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uzip@0.20201231.0:
+  version "0.20201231.0"
+  resolved "https://registry.yarnpkg.com/uzip/-/uzip-0.20201231.0.tgz#9e64b065b9a8ebf26eb7583fe8e77e1d9a15ed14"
+  integrity sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==
 
 v8-to-istanbul@^8.1.0:
   version "8.1.1"


### PR DESCRIPTION
# Describe your changes

Added a new function in `utils` called CompressImage that does exactly what the name suggests. This seems to run pretty quickly but for edge cases I added in a new useState that will activate when the compression function starts and will remove the select image button from the screen.

Added a max height of 90vh to the CreateRoute parent popup, replaced the base input html component with a style to mimic our native base buttons.

![image](https://user-images.githubusercontent.com/31017536/219729455-3e822d17-0e2a-48d6-b3d9-bcbe81c32627.png)

![image](https://user-images.githubusercontent.com/31017536/219729916-93f7c00c-fce6-4a53-adfa-91a5a6fcaed8.png)

![image](https://user-images.githubusercontent.com/31017536/219730066-3a094203-2193-4999-8b0f-b6ac6285062a.png)


# Issue ticket number and link
#77 