### PR TITLE
Navbar/user avatar

### DIFF
--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,8 +1,13 @@
 import { HStack, VStack,  Box , Button, Text, Menu, Pressable, HamburgerIcon} from 'native-base';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { auth } from '../xplat/Firebase';
+import { useContext } from 'react';
+import { AuthContext } from '../utils/AuthContext';
+import './css/feed.css';
 
 export const NavBar = () => {
+  const [searchParams] = useSearchParams();
+  const authContext = useContext(AuthContext);
   const navigate = useNavigate();
   return (
     <Box height='1' zIndex={100}>
@@ -29,10 +34,18 @@ export const NavBar = () => {
               FAQ
             </Text>
           </Button>
-          <Box top={'15px'} right='1%' position={'fixed'}>
-            <Menu  trigger={triggerProps => {
+          <HStack right='1%' position={'fixed'} alignSelf='center' space={2}>
+            {authContext.user && <img src={authContext.user.avatarUrl} alt='profile' className='nav-avatar'
+              onClick={() => {
+                const path = window.location.href.split('?')[0];
+                if (path.endsWith('/profile') && searchParams.get('uid') === authContext.user!.docRefId)
+                  return;
+
+                navigate('/profile?uid=' + authContext.user?.docRefId);
+              }}/>}
+            <Menu trigger={triggerProps => {
               return <Pressable accessibilityLabel="Online session options" {...triggerProps} >
-                <HamburgerIcon size='lg' />
+                <HamburgerIcon position='relative' top={'5px'} size='lg' />
               </Pressable>;
             }}>
               <Menu.Item onPress={() => {
@@ -42,7 +55,7 @@ export const NavBar = () => {
                 
               }}>Logout</Menu.Item>
             </Menu>
-          </Box>
+          </HStack>
         </HStack>
       </VStack>
     </Box>

--- a/src/components/Profile/ProfileBanner.tsx
+++ b/src/components/Profile/ProfileBanner.tsx
@@ -114,9 +114,10 @@ const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
               {user.numFollowing} Following
             </Text>
           </HStack>
+          {authContext.user.docRefId !== user.userObject.docRef!.id &&  
           <Button position='absolute' bottom={2} onPress={() => setEditPermissionModal(true)}>
             <Text variant='button'>Edit User Permissions</Text>
-          </Button>
+          </Button>}
         </VStack>
       </HStack>
     </>

--- a/src/components/css/feed.css
+++ b/src/components/css/feed.css
@@ -7,6 +7,20 @@
     border: 1px solid black;
 }
 
+.nav-avatar {
+    border-radius: 100%;
+    width: 32px;
+    height: 32px;
+    align-self: center;
+    border: 1px solid black;
+    
+}
+
+.nav-avatar:hover {
+    border: 1px solid #0891B2;
+    cursor: pointer;
+}
+
 .avatar-profile {
     border-radius: 100%;
     width: 15%;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -9,15 +9,15 @@ import { NavBar } from '../components/NavigationBar';
 import { buildUserByIDFetcher } from '../utils/queries';
 import { CURSOR_INCREMENT } from '../utils/constants';
 
-const Profile = ({userOverride}: {userOverride?: string}) => {
+const Profile = () => {
   const [posts, setPosts] = useState<Post[]>([]);
   const [postCursor, setPostCursor] = useState<QueryCursor<Post>>();
   const [hasMorePosts, setHasMorePosts] = useState(false);
   const [selectedPost, setSelectedPost] = useState<Post | undefined>();
   const [searchParams] = useSearchParams();
   const {isLoading, isError, data} = 
-        useQuery(['userprofile', {uid: userOverride ? userOverride : searchParams.get('uid')}], 
-          buildUserByIDFetcher(userOverride ? userOverride : searchParams.get('uid')!));
+        useQuery(['userprofile', {uid:  searchParams.get('uid')}], 
+          buildUserByIDFetcher(searchParams.get('uid')!));
 
   const handlePostClick = (post: Post) => {
     if (post === selectedPost)


### PR DESCRIPTION
# Describe your changes
Adds the user avatar to the NavBar. Upon being clicked it navigates the user to their profile as long as they are not currently on their profile page.
This PR also includes extra logic for the UpdateUserPermissions modal so that it's hidden on the user's own profile, and removes the unneeded userOverride prop in the Profile page,
![image](https://user-images.githubusercontent.com/31017536/219758216-565a385c-472f-4802-9eec-ea8a04e54a83.png)

# Issue ticket number and link
#81 