### PR TITLE
Frfr last auth change

### DIFF
--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -36,9 +36,7 @@ export const NavBar = () => {
               </Pressable>;
             }}>
               <Menu.Item onPress={() => {
-                auth.signOut().then( () => {
-                  navigate('/');
-                });
+                auth.signOut();
                 
               }}>Logout</Menu.Item>
             </Menu>

--- a/src/utils/ProtectedRoute.tsx
+++ b/src/utils/ProtectedRoute.tsx
@@ -8,7 +8,7 @@ export default function ProtectedRoute({redirectTo}:
   {redirectTo: string}){
    
   const authValue = useContext(AuthContext);
-  if (authValue.userDataPresent){
+  if (authValue.waiting === false){
     if(authValue.user === null || authValue.user.status < UserStatus.Employee){
       return(<Navigate to={redirectTo}/>);
     }


### PR DESCRIPTION
# Describe your changes
The `AuthContext` manager was defaulted to false, which worked most of the time but there was a chance that user auth would be checked by `ProtectedRoute` before `AuthContext` was able to get a response from Firebase.

To solve this, I introduced a new field called `waiting` to `AuthContext` that defaults to `true` so that `ProtecedRoute` only checks user permission level when a response is received.

Along with this change, I removed the navigate function from the signout button since this is done automatically due to the `auth` change.
# Issue ticket number and link
#82 