### PR TITLE
Add reporting functionality to web

### DIFF
--- a/src/components/Post/Comment/CommentDisplay.tsx
+++ b/src/components/Post/Comment/CommentDisplay.tsx
@@ -1,11 +1,10 @@
 import { Comment } from '../../../xplat/types/comment';
-import { useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 import { buildCommentFetcher } from '../../../utils/queries';
-import { Box, Text, Skeleton } from 'native-base';
+import { Box, Text, Skeleton, HStack } from 'native-base';
 import '../../css/feed.css';
-import { User } from '../../../xplat/types/user';
 import AuthorHandle from '../../User/AuthorHandle';
+import ReportButton from '../../Reports/ReportButton';
 
 const CommentDisplay = ({comment}: {comment: Comment}) => {
   const { isLoading, isError, data } = useQuery(comment.docRef!.id, buildCommentFetcher(comment));
@@ -25,7 +24,10 @@ const CommentDisplay = ({comment}: {comment: Comment}) => {
 
   return (
     <Box flexDir={'column'} p={1} background={'primary.200'} borderRadius={'md'} borderWidth={1}>
-      <AuthorHandle author={data.author}/>
+      <HStack justifyContent='space-between'>
+        <AuthorHandle author={data.author}/>
+        <ReportButton content={comment}/>
+      </HStack>
       <Text fontSize={'sm'}>{data.body}</Text>
       <Text fontSize={'xs'} color='gray.400'>{data.timestamp.toLocaleString()}</Text>
     </Box>

--- a/src/components/Post/PostInFeed.tsx
+++ b/src/components/Post/PostInFeed.tsx
@@ -5,6 +5,7 @@ import '../css/feed.css';
 import AuthorHandle from '../User/AuthorHandle';
 import PostMedia from './PostMedia';
 import { buildPostFetcher } from '../../utils/queries';
+import ReportButton from '../Reports/ReportButton';
 
 const PostInFeed = ({ post }: { post: Post}) => {
   const { isLoading, isError, error, data } = useQuery(post.docRef!.id, buildPostFetcher(post));
@@ -25,7 +26,10 @@ const PostInFeed = ({ post }: { post: Post}) => {
   return (
     <Box p={1} m={1} background={'primary.200'} 
       width='100%' borderRadius={'md'} borderWidth={1} alignSelf={'center'}>
-      <AuthorHandle author={data.author}/>
+      <HStack justifyContent='space-between'>
+        <AuthorHandle author={data.author}/>
+        <ReportButton content={post}/>
+      </HStack>
       <Text flexWrap={'wrap'} noOfLines={4} p={1} fontSize='md'>{data.body}</Text>
       {data.imageCount > 0 && <PostMedia imageContent={data.imageURLs} videoContent={data.videoContent}/>}
       <HStack>

--- a/src/components/Profile/ProfileBanner.tsx
+++ b/src/components/Profile/ProfileBanner.tsx
@@ -6,6 +6,7 @@ import '../css/feed.css';
 import { FetchedUserProfile } from '../../utils/queries';
 import { AuthContext } from '../../utils/AuthContext';
 import { UserStatus } from '../../xplat/types';
+import ReportButton from '../Reports/ReportButton';
 
 const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
   const [promoteOrDemote, setPromoteOrDemote] = useState<string>('promote');
@@ -119,6 +120,7 @@ const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
             <Text variant='button'>Edit User Permissions</Text>
           </Button>}
         </VStack>
+        <ReportButton content={user.userObject}/>
       </HStack>
     </>
   );

--- a/src/components/Reports/ReportButton.tsx
+++ b/src/components/Reports/ReportButton.tsx
@@ -13,7 +13,7 @@ const ReportButton = ({content}: {content: Post | Comment | User}) => {
       return;
     if (!reported)
       authContext.user.userObject.addReport(content).then(() => setReported(true));
-    else if (content instanceof Post || content instanceof Comment)
+    else
       authContext.user.userObject.removeReport(content).then(() => setReported(false));
   }
 

--- a/src/components/Reports/ReportButton.tsx
+++ b/src/components/Reports/ReportButton.tsx
@@ -1,0 +1,41 @@
+import { Pressable, WarningOutlineIcon, WarningIcon } from 'native-base';
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '../../utils/AuthContext';
+import { Comment, Post, User } from '../../xplat/types';
+
+const ReportButton = ({content}: {content: Post | Comment | User}) => {
+  const authContext = useContext(AuthContext);
+  const [reported, setReported] = useState<boolean | undefined>();
+
+  function handlePressReport()
+  {
+    if (reported === undefined || authContext.user == null)
+      return;
+    if (!reported)
+      authContext.user.userObject.addReport(content).then(() => setReported(true));
+    else if (content instanceof Post || content instanceof Comment)
+      authContext.user.userObject.removeReport(content).then(() => setReported(false));
+  }
+
+  useEffect( () => {
+    if (authContext.user == null)
+      return;
+    
+    authContext.user.userObject.alreadyReported(content).then(setReported);
+
+  }, [authContext.user]);
+
+  return (
+    <Pressable disabled={reported === undefined} onPress={() => handlePressReport()}>
+      {reported !== undefined && 
+        (reported ? 
+          <WarningIcon color='red.400' alignSelf='center'/> 
+          :
+          <WarningOutlineIcon alignSelf='center'/>
+        )
+      }
+    </Pressable>
+  );
+};
+
+export default ReportButton;

--- a/src/components/User/AuthorHandle.tsx
+++ b/src/components/User/AuthorHandle.tsx
@@ -35,7 +35,7 @@ const AuthorHandle = ({ author }: { author: User }) => {
       <HStack space={1}>
         <Skeleton borderRadius={'100'} width='8%' isLoaded={false} />
         <Skeleton.Text lines={1} width='60%' alignSelf={'center'} />
-        <Skeleton.Text lines={1} width='60%' alignSelf={'center'} />
+        <Skeleton.Text lines={1} width='20%' alignSelf={'center'} />
       </HStack>
     );
   }


### PR DESCRIPTION
# Describe your changes
 - Creates `ReportButton` component that displays either a warning icon outline or warning icon depending if the current user reported a piece of content
 - When pressed, calls the `User.addReport` or `User.removeReport` functions on the piece of content.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/31017536/222913878-fce76271-9db3-4654-8872-37aaa66dc747.png">


Its been tested and works on each kind of content (after being reported they show on the Reports page).
# Issue ticket number and link
closes #86 