### PR TITLE
change a user's status through ProfileBanner

### DIFF
--- a/src/components/Profile/ProfileBanner.tsx
+++ b/src/components/Profile/ProfileBanner.tsx
@@ -13,14 +13,19 @@ const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
   const authContext = useContext(AuthContext);
   const [newPermission, setNewPermission] = useState<number>(0);
   const [actionDescription, setActionDescription] = useState<string>('');
+  const [passwordCheck, setPasswordCheck] = useState<string>('');
 
   const handleEditPermission = () => {
     setEditPermissionModal(false);
-    console.log('will change permission to ' + newPermission);
+
+    if (user != undefined) {
+      console.log('will change permission to ' + UserStatus[newPermission]);
+      authContext.user?.userObject.editOtherStatus(passwordCheck, user?.userObject, newPermission, actionDescription);
+    } 
   };
 
-  const managerSwap = () => {
-    console.log('Will make this user manager and remove manager status from current manager');
+  const getStatusTitle = (status: number) => {
+    return UserStatus[status];
   };
 
   if (user === undefined)
@@ -47,12 +52,8 @@ const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
         onClose={() => setEditPermissionModal(false)} modal>
         <Box p={4} w='100%' h='100%' borderRadius='sm'>
           <Text alignSelf='center' bold fontSize='lg'>Edit user permission level</Text>
-          { user.status == UserStatus.Employee && authContext.user.status >= UserStatus.Manager
-            && 
-            <Button onPress={managerSwap} marginTop='1' m='3'>
-              <Text variant='button'>Make Manager</Text>
-            </Button>
-          }
+          <Text alignSelf='center' fontSize='sm' marginBottom='1'>
+            Current permission level: {getStatusTitle(user.status)}</Text>
           <Radio.Group name='Permission' value={promoteOrDemote} 
             onChange={(nextValue) => setPromoteOrDemote(nextValue)}>
             <Radio value='promote'>Promote</Radio>
@@ -63,25 +64,35 @@ const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
             promoteOrDemote === 'promote' && user.status > UserStatus.Banned ?
               <Select placeholder='Select permission level' 
                 onValueChange={(valueString) => setNewPermission(parseInt(valueString))}>
+                {user.status < UserStatus.Manager && authContext.user.status >= UserStatus.Manager &&
+                  <Select.Item label='Manager' value='4' />}
                 {user.status < UserStatus.Employee && authContext.user.status >= UserStatus.Manager &&
-                <Select.Item label='Employee' value='3' />}
-                {user.status < UserStatus.Approved && <Select.Item label='Approved (can post)' value='2' />}
-                {user.status < UserStatus.Verified && 
+                  <Select.Item label='Employee' value='3' />}
+                {user.status < UserStatus.Approved &&
+                  <Select.Item label='Approved (can post)' value='2' />}
+                {user.status < UserStatus.Verified &&
                   <Select.Item label='Verified (can login, cannot post)' value='1' />}
-                {user.status < UserStatus.Unverified && <Select.Item label='Unverified (cannot login)' value='0' />}
+                {user.status < UserStatus.Unverified &&
+                  <Select.Item label='Unverified (cannot login)' value='0' />}
               </Select>
               :
               /*Demote the user profile*/
               <Select placeholder='Select permission level'
                 onValueChange={(valueString) => setNewPermission(parseInt(valueString))}>
-                {user.status > UserStatus.Approved && <Select.Item label='Approved (can post)' value='2' />}
-                {user.status > UserStatus.Verified && 
+                {user.status > UserStatus.Employee && authContext.user.status >= UserStatus.Manager &&
+                  <Select.Item label='Employee' value='3' />}
+                {user.status > UserStatus.Approved &&
+                  <Select.Item label='Approved (can post)' value='2' />}
+                {user.status > UserStatus.Verified &&
                   <Select.Item label='Verified (can login, cannot post)' value='1' />}
-                {user.status > UserStatus.Unverified && <Select.Item label='Unverified (cannot login)' value='0' />}
+                {user.status > UserStatus.Unverified &&
+                  <Select.Item label='Unverified (cannot login)' value='0' />}
               </Select>
           }
           <Input type='text' multiline placeholder='Reason for action' marginY='1' numberOfLines={3}
             onChangeText={(text) => setActionDescription(text)} />
+          <Input type='text' multiline placeholder='Enter your password' marginY='1' numberOfLines={1}
+            onChangeText={(text) => setPasswordCheck(text)} />
           <HStack>
             <Button onPress={() => setEditPermissionModal(false)} marginTop='1'>
               <Text variant='button'>Cancel</Text>

--- a/src/components/Profile/ProfileBanner.tsx
+++ b/src/components/Profile/ProfileBanner.tsx
@@ -7,6 +7,10 @@ import { FetchedUserProfile } from '../../utils/queries';
 import { AuthContext } from '../../utils/AuthContext';
 import { UserStatus } from '../../xplat/types';
 
+const getStatusTitle = (status: number) => {
+  return UserStatus[status];
+};
+
 const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
   const [promoteOrDemote, setPromoteOrDemote] = useState<string>('promote');
   const [editPermissionModal, setEditPermissionModal] = useState<boolean>(false);
@@ -26,10 +30,6 @@ const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
       authContext.user?.userObject.editOtherStatus(passwordCheck, user?.userObject, newPermission, actionDescription);
       user.status = newPermission;
     }
-  };
-
-  const getStatusTitle = (status: number) => {
-    return UserStatus[status];
   };
 
   if (user === undefined)

--- a/src/components/Profile/ProfileBanner.tsx
+++ b/src/components/Profile/ProfileBanner.tsx
@@ -1,5 +1,5 @@
 import { useState, useContext } from 'react';
-import { Box, HStack, Text, Input, VStack, Skeleton, Select, Button, Radio } from 'native-base';
+import { Box, HStack, Text, Input, VStack, Skeleton, Select, Button, Radio, SunIcon} from 'native-base';
 import Popup from 'reactjs-popup';
 import 'reactjs-popup/dist/index.css';
 import '../css/feed.css';
@@ -95,13 +95,13 @@ const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
           }
           <Input type='text' multiline placeholder='Reason for action' marginY='1' numberOfLines={3}
             onChangeText={(text) => setActionDescription(text)} />
-          <Input type={showPassword ? 'text' : 'password'}  placeholder="Enter your password" marginY='1'
+          <Input type={showPassword ? 'text' : 'password'} placeholder="Enter your password" marginY='1'
             onChangeText={(text) => setPasswordCheck(text)}
             InputRightElement={
-              <Button size="xs" onPress={handleClick}>
-                {showPassword ? 'Hide' : 'Show'}
+              <Button backgroundColor={'transparent'} onPress={handleClick}>
+                {<SunIcon color={showPassword ? 'blue.500' : 'black'}/>}
               </Button>
-            } />
+            }/>
           <HStack>
             <Button onPress={() => setEditPermissionModal(false)} marginTop='1'>
               <Text variant='button'>Cancel</Text>

--- a/src/components/Profile/ProfileBanner.tsx
+++ b/src/components/Profile/ProfileBanner.tsx
@@ -14,6 +14,9 @@ const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
   const [newPermission, setNewPermission] = useState<number>(0);
   const [actionDescription, setActionDescription] = useState<string>('');
   const [passwordCheck, setPasswordCheck] = useState<string>('');
+  const [showPassword, setShowPassword] = useState(false);
+
+  const handleClick = () => setShowPassword(!showPassword);
 
   const handleEditPermission = () => {
     setEditPermissionModal(false);
@@ -21,7 +24,8 @@ const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
     if (user != undefined) {
       console.log('will change permission to ' + UserStatus[newPermission]);
       authContext.user?.userObject.editOtherStatus(passwordCheck, user?.userObject, newPermission, actionDescription);
-    } 
+      user.status = newPermission;
+    }
   };
 
   const getStatusTitle = (status: number) => {
@@ -91,8 +95,13 @@ const ProfileBanner = ({user}: {user: FetchedUserProfile | undefined}) => {
           }
           <Input type='text' multiline placeholder='Reason for action' marginY='1' numberOfLines={3}
             onChangeText={(text) => setActionDescription(text)} />
-          <Input type='text' multiline placeholder='Enter your password' marginY='1' numberOfLines={1}
-            onChangeText={(text) => setPasswordCheck(text)} />
+          <Input type={showPassword ? 'text' : 'password'}  placeholder="Enter your password" marginY='1'
+            onChangeText={(text) => setPasswordCheck(text)}
+            InputRightElement={
+              <Button size="xs" onPress={handleClick}>
+                {showPassword ? 'Hide' : 'Show'}
+              </Button>
+            } />
           <HStack>
             <Button onPress={() => setEditPermissionModal(false)} marginTop='1'>
               <Text variant='button'>Cancel</Text>


### PR DESCRIPTION
# Describe your changes
You can now use the dropdowns to view all status levels you can change this user to.
Allows for multiple managers.
Managers are the only ones who can promote/demote managers & employees.
Includes new xplat version that checks status with fresh data.

screenshots show dropdown & hide/show password input
![image](https://user-images.githubusercontent.com/73561858/224174663-20b1ad5c-03a5-44fe-be6f-9a3702968dc8.png)
![image](https://user-images.githubusercontent.com/73561858/224174706-8a5588b6-a8d0-45f5-b0bb-a0bbff543c88.png)

# Issue ticket number and link
closes #87, #54, #53