### PR TITLE
Create editRoute modal for editing active routes

### DIFF
--- a/src/components/Route/EditRoute.tsx
+++ b/src/components/Route/EditRoute.tsx
@@ -139,12 +139,12 @@ const EditRoute = ({route, open, setOpen}:
               }
             </>
         }
-        <HStack alignItems='center'space={1}width='100%'>
+        <HStack alignItems='center'space={1} width='100%'>
           <Text bold >Description: </Text>
           <Input type='text' value={description} onChangeText={setDescription} width='75%' 
             multiline numberOfLines={2} />
         </HStack>
-        <HStack alignItems='center'space={1}width='100%'>
+        <HStack alignItems='center'space={1} width='100%'>
           <Text bold >Setter: </Text>
           <Radio.Group name='Setter' defaultValue='User' onChange={(nextVal) => setSetterType(nextVal)}>
             <HStack alignItems='center'space={2}>
@@ -165,7 +165,7 @@ const EditRoute = ({route, open, setOpen}:
               width='50%' 
             />
         }
-        <HStack>
+        <HStack alignItems='center'space={1} width='100%'>
           <Text bold >Natural Rules: </Text>
           <Select placeholder='Natural Rules' onValueChange={(rulesString) => {
             const rules = rulesString as NaturalRules;
@@ -176,7 +176,7 @@ const EditRoute = ({route, open, setOpen}:
             })}
           </Select>
         </HStack>
-        <HStack alignItems='center'space={1}width='100%'>
+        <HStack alignItems='center'space={1} width='100%'>
           <Text bold >Rope: </Text>
           <Select defaultValue={rope === undefined ? '1' : rope.toString()} 
             minWidth='90%' onValueChange={(itemValue) => setRope(parseInt(itemValue))}>
@@ -185,7 +185,7 @@ const EditRoute = ({route, open, setOpen}:
             })}
           </Select>
         </HStack>
-        <HStack alignItems='center'space={1}width='100%'>
+        <HStack alignItems='center'space={1} width='100%'>
           <Text bold >Color: </Text>
           <Select defaultValue={color}
             minWidth='90%' onValueChange={(itemValue) => setColor(itemValue)}>

--- a/src/components/Route/EditRoute.tsx
+++ b/src/components/Route/EditRoute.tsx
@@ -1,6 +1,5 @@
-import { LazyStaticImage, Route, RouteClassifier, 
-  RouteColor, RouteStatus, User, NaturalRules, FetchedRoute, invalidateDocRefId } from '../../xplat/types';
-import { Box, Text, HStack, Input, VStack, Radio, Button, Select } from 'native-base';
+import { RouteColor, User, NaturalRules, FetchedRoute, invalidateDocRefId } from '../../xplat/types';
+import { Text, HStack, Input, VStack, Radio, Button, Select } from 'native-base';
 import {compressImage} from '../../utils/CompressImage';
 import Popup from 'reactjs-popup';
 import 'reactjs-popup/dist/index.css';
@@ -12,8 +11,8 @@ const Ropes = [
   '1', '2', '3', '4', '5', '6', '7', '8', '9'
 ];
 
-const EditRoute = ({route}: {route: FetchedRoute}) => {
-  const [showPopup, setShowPopup] = useState<boolean>(false);
+const EditRoute = ({route, open, setOpen}: 
+  {route: FetchedRoute, open: boolean, setOpen: (arg0: boolean) => void}) => {
   const [description, setDescription] = useState(route.description);
   const [setter, setSetter] = useState<User | undefined>(route.setter);
   const [rope, setRope] = useState<number | undefined>(route.rope);
@@ -70,7 +69,9 @@ const EditRoute = ({route}: {route: FetchedRoute}) => {
       console.log('route edited');
       invalidateDocRefId(route.routeObject.getId());
       queryClient.invalidateQueries({queryKey: route.routeObject.getId()});
-      queryClient.invalidateQueries({queryKey: ['route', {id: route.routeObject.getId()}], exact: true});
+      queryClient.invalidateQueries(
+        {queryKey: ['route', {id: route.routeObject.getId()}], exact: true}
+      );
     }).catch((err) => {
       console.log('failed to edit route');
       console.log(err);
@@ -78,12 +79,11 @@ const EditRoute = ({route}: {route: FetchedRoute}) => {
   }
 
   return (
-    <Popup trigger={<button className='native-button' style=
-      {{height: 'fit-content', top: 0}}>Edit Route</button>} open={showPopup} onOpen={() => setShowPopup(true)} 
-    modal nested onClose={() => {
-      setShowPopup(false); 
-      resetStates();
-    }}>
+    <Popup open={open} onOpen={() => setOpen(true)} 
+      modal nested onClose={() => {
+        setOpen(false); 
+        resetStates();
+      }}>
       <VStack width='100%' space={1} maxH='90vh' overflowY='scroll' p={1}>
         <Text bold alignSelf='center' variant='header'>{route.name}</Text>
         <Text alignSelf='center'>
@@ -99,8 +99,8 @@ const EditRoute = ({route}: {route: FetchedRoute}) => {
               { // show compression text if image is being compressed
                 thumbnail !== undefined && 
                 <>
-                  <img src={thumbnail} alt='thumbnail' width='200px'/>
-                  <HStack space='2'>
+                  <img src={thumbnail} alt='thumbnail' className='route-popup-avatar'/>
+                  <HStack alignItems='center'space={2}>
                     <Text variant='subtext'>Thumbnail preview</Text>
                     <input className='hidden-input' type='file' id="file" accept='image/*'
                       onChange={handleFileSelect} />
@@ -120,7 +120,7 @@ const EditRoute = ({route}: {route: FetchedRoute}) => {
                     <Text variant='subtext'>Compressing image...</Text>
                     :
                     <>
-                      <img src={URL.createObjectURL(thumbnailFile)} alt='thumbnail' width='200px'/>
+                      <img src={URL.createObjectURL(thumbnailFile)} alt='thumbnail' className='route-popup-avatar'/>
                       <button className='native-button' onClick={() => {
                         setShowStoredThumbnail(true);
                         setThumbnailFile(undefined);
@@ -139,14 +139,14 @@ const EditRoute = ({route}: {route: FetchedRoute}) => {
               }
             </>
         }
-        <HStack width='100%'>
-          <Text bold width='10%'>Description: </Text>
-          <Input type='text' value={description} onChangeText={setDescription} width='90%' multiline />
+        <HStack alignItems='center'space={1}width='100%'>
+          <Text bold >Description: </Text>
+          <Input type='text' value={description} onChangeText={setDescription} width='75%' multiline />
         </HStack>
-        <HStack width='100%'>
-          <Text bold width='10%'>Setter: </Text>
+        <HStack alignItems='center'space={1}width='100%'>
+          <Text bold >Setter: </Text>
           <Radio.Group name='Setter' defaultValue='User' onChange={(nextVal) => setSetterType(nextVal)}>
-            <HStack space={2}>
+            <HStack alignItems='center'space={2}>
               <Radio value='User'>User</Radio>
               <Radio value='Custom'>Custom</Radio>
             </HStack>
@@ -156,10 +156,16 @@ const EditRoute = ({route}: {route: FetchedRoute}) => {
           setterType === 'User' ?
             <Text>This will be a user search component</Text>
             :
-            <Input left='10%' type='text' value={setterRawName} onChangeText={setSetterRawName} width='90%' />
+            <Input 
+              type='text' 
+              value={setterRawName} 
+              placeholder='Non-user setter' 
+              onChangeText={setSetterRawName} 
+              width='50%' 
+            />
         }
         <HStack>
-          <Text bold width='10%'>Natural Rules: </Text>
+          <Text bold >Natural Rules: </Text>
           <Select placeholder='Natural Rules' onValueChange={(rulesString) => {
             const rules = rulesString as NaturalRules;
             setNaturalRules(rules);
@@ -169,8 +175,8 @@ const EditRoute = ({route}: {route: FetchedRoute}) => {
             })}
           </Select>
         </HStack>
-        <HStack width='100%'>
-          <Text bold width='10%'>Rope: </Text>
+        <HStack alignItems='center'space={1}width='100%'>
+          <Text bold >Rope: </Text>
           <Select defaultValue={rope === undefined ? '1' : rope.toString()} 
             minWidth='90%' onValueChange={(itemValue) => setRope(parseInt(itemValue))}>
             {Ropes.map((rope) => {
@@ -178,8 +184,8 @@ const EditRoute = ({route}: {route: FetchedRoute}) => {
             })}
           </Select>
         </HStack>
-        <HStack width='100%'>
-          <Text bold width='10%'>Color: </Text>
+        <HStack alignItems='center'space={1}width='100%'>
+          <Text bold >Color: </Text>
           <Select defaultValue={color}
             minWidth='90%' onValueChange={(itemValue) => setColor(itemValue)}>
             {Object.values(RouteColor).map((color) => {
@@ -187,13 +193,22 @@ const EditRoute = ({route}: {route: FetchedRoute}) => {
             })}
           </Select>
         </HStack>
-        <Button onPress={() => {
-          handleSubmit().finally( () => {
-            setShowPopup(false);
-          });
-        }} alignSelf='center'>
-          <Text variant='button'>Submit Changes</Text>
-        </Button>
+        <HStack justifyContent='center' space={2}>
+          <Button onPress={() => {
+            setOpen(false);
+          }}>
+            <Text variant='button'>
+              Cancel
+            </Text>
+          </Button>
+          <Button onPress={() => {
+            handleSubmit().finally( () => {
+              setOpen(false);
+            });
+          }} alignSelf='center'>
+            <Text variant='button'>Submit Changes</Text>
+          </Button>
+        </HStack>
       </VStack>
     </Popup>
   );

--- a/src/components/Route/EditRoute.tsx
+++ b/src/components/Route/EditRoute.tsx
@@ -1,0 +1,203 @@
+import { LazyStaticImage, Route, RouteClassifier, 
+  RouteColor, RouteStatus, User, NaturalRules, FetchedRoute, invalidateDocRefId } from '../../xplat/types';
+import { Box, Text, HStack, Input, VStack, Radio, Button, Select } from 'native-base';
+import {compressImage} from '../../utils/CompressImage';
+import Popup from 'reactjs-popup';
+import 'reactjs-popup/dist/index.css';
+import '../css/feed.css';
+import { useState } from 'react';
+import { queryClient } from '../../App';
+
+const Ropes = [
+  '1', '2', '3', '4', '5', '6', '7', '8', '9'
+];
+
+const EditRoute = ({route}: {route: FetchedRoute}) => {
+  const [showPopup, setShowPopup] = useState<boolean>(false);
+  const [description, setDescription] = useState(route.description);
+  const [setter, setSetter] = useState<User | undefined>(route.setter);
+  const [rope, setRope] = useState<number | undefined>(route.rope);
+  const [thumbnail, setThumbnail] = useState<string | undefined>(route.thumbnailUrl);
+  const [showStoredThumbnail, setShowStoredThumbnail] = useState<boolean>(route.thumbnailUrl !== undefined);
+  const [thumbnailFile, setThumbnailFile] = useState<File | undefined>(undefined);
+  const [color, setColor] = useState<string | undefined>(route.color);
+  const [setterRawName, setSetterRawName] = useState<string | undefined>(route.setterRawName);
+  const [setterType, setSetterType] = useState<string>('User');
+  const [naturalRules, setNaturalRules] = useState<NaturalRules | undefined>(route.naturalRules);
+  const [imageCompressing, setImageCompressing] = useState<boolean>(false);
+
+  function resetStates() {
+    setDescription(route.description);
+    setSetter(route.setter);
+    setRope(route.rope);
+    setThumbnail(route.thumbnailUrl);
+    setShowStoredThumbnail(route.thumbnailUrl !== undefined);
+    setThumbnailFile(undefined);
+    setColor(route.color);
+    setSetterRawName(route.setterRawName);
+    setSetterType('User');
+    setNaturalRules(route.naturalRules);
+  }
+
+  function handleFileSelect(event: React.ChangeEvent<HTMLInputElement>) {
+    if (event.target.files === null)
+    {
+      setShowStoredThumbnail(true);
+      return;
+    }
+    setShowStoredThumbnail(false);
+    setImageCompressing(true);
+    compressImage(event.target.files[0]).then((compressedFile) => {
+      setThumbnailFile(compressedFile);
+    }).catch((err) => {
+      console.log('failed to compress image');
+      console.log(err);
+    });
+    setImageCompressing(false);
+  }
+
+  async function handleSubmit()
+  {
+    await route.routeObject.edit({
+      description: description,
+      setter: setter,
+      rope: rope,
+      thumbnail: thumbnailFile,
+      color: color,
+      setterRawName: setterRawName,
+      naturalRules: naturalRules
+    }).then(() => {
+      console.log('route edited');
+      invalidateDocRefId(route.routeObject.getId());
+      queryClient.invalidateQueries({queryKey: route.routeObject.getId()});
+      queryClient.invalidateQueries({queryKey: ['route', {id: route.routeObject.getId()}], exact: true});
+    }).catch((err) => {
+      console.log('failed to edit route');
+      console.log(err);
+    });
+  }
+
+  return (
+    <Popup trigger={<button className='native-button' style=
+      {{height: 'fit-content', top: 0}}>Edit Route</button>} open={showPopup} onOpen={() => setShowPopup(true)} 
+    modal nested onClose={() => {
+      setShowPopup(false); 
+      resetStates();
+    }}>
+      <VStack width='100%' space={1} maxH='90vh' overflowY='scroll' p={1}>
+        <Text bold alignSelf='center' variant='header'>{route.name}</Text>
+        <Text alignSelf='center'>
+          <Text bold>
+            Route Grade: 
+          </Text>
+          {' ' + route.gradeDisplayString}
+        </Text>
+        <Text>Route Thumbnail</Text>
+        { // show thumbnail stored in Firebase
+          showStoredThumbnail ?
+            <>
+              { // show compression text if image is being compressed
+                thumbnail !== undefined && 
+                <>
+                  <img src={thumbnail} alt='thumbnail' width='200px'/>
+                  <HStack space='2'>
+                    <Text variant='subtext'>Thumbnail preview</Text>
+                    <input className='hidden-input' type='file' id="file" accept='image/*'
+                      onChange={handleFileSelect} />
+                    <label htmlFor="file" className='native-button'>Replace photo</label>
+                  </HStack> 
+                </>
+                
+              }
+
+            </>
+            :
+            // show thumbnail preview and remove button
+            <>
+              {thumbnailFile !== undefined ?
+                <>
+                  {imageCompressing ? 
+                    <Text variant='subtext'>Compressing image...</Text>
+                    :
+                    <>
+                      <img src={URL.createObjectURL(thumbnailFile)} alt='thumbnail' width='200px'/>
+                      <button className='native-button' onClick={() => {
+                        setShowStoredThumbnail(true);
+                        setThumbnailFile(undefined);
+                      }}>
+                        Reset to stored thumbnail
+                      </button>
+                    </>
+                  }
+                </>
+                :
+                <>
+                  <input className='hidden-input' type='file' id="file" accept='image/*'
+                    onChange={handleFileSelect} />
+                  <label htmlFor="file" className='native-button'>Select photo</label>
+                </>
+              }
+            </>
+        }
+        <HStack width='100%'>
+          <Text bold width='10%'>Description: </Text>
+          <Input type='text' value={description} onChangeText={setDescription} width='90%' multiline />
+        </HStack>
+        <HStack width='100%'>
+          <Text bold width='10%'>Setter: </Text>
+          <Radio.Group name='Setter' defaultValue='User' onChange={(nextVal) => setSetterType(nextVal)}>
+            <HStack space={2}>
+              <Radio value='User'>User</Radio>
+              <Radio value='Custom'>Custom</Radio>
+            </HStack>
+          </Radio.Group>
+        </HStack>
+        {
+          setterType === 'User' ?
+            <Text>This will be a user search component</Text>
+            :
+            <Input left='10%' type='text' value={setterRawName} onChangeText={setSetterRawName} width='90%' />
+        }
+        <HStack>
+          <Text bold width='10%'>Natural Rules: </Text>
+          <Select placeholder='Natural Rules' onValueChange={(rulesString) => {
+            const rules = rulesString as NaturalRules;
+            setNaturalRules(rules);
+          }} defaultValue={route.naturalRules}>
+            {Object.values(NaturalRules).map((rules) => {
+              return <Select.Item key={rules} label={rules} value={rules} />;
+            })}
+          </Select>
+        </HStack>
+        <HStack width='100%'>
+          <Text bold width='10%'>Rope: </Text>
+          <Select defaultValue={rope === undefined ? '1' : rope.toString()} 
+            minWidth='90%' onValueChange={(itemValue) => setRope(parseInt(itemValue))}>
+            {Ropes.map((rope) => {
+              return <Select.Item key={rope} label={rope.toString()} value={rope.toString()} />;
+            })}
+          </Select>
+        </HStack>
+        <HStack width='100%'>
+          <Text bold width='10%'>Color: </Text>
+          <Select defaultValue={color}
+            minWidth='90%' onValueChange={(itemValue) => setColor(itemValue)}>
+            {Object.values(RouteColor).map((color) => {
+              return <Select.Item key={color} label={color} value={color} />;
+            })}
+          </Select>
+        </HStack>
+        <Button onPress={() => {
+          handleSubmit().finally( () => {
+            setShowPopup(false);
+          });
+        }} alignSelf='center'>
+          <Text variant='button'>Submit Changes</Text>
+        </Button>
+      </VStack>
+    </Popup>
+  );
+
+};
+
+export default EditRoute;

--- a/src/components/Route/EditRoute.tsx
+++ b/src/components/Route/EditRoute.tsx
@@ -80,7 +80,7 @@ const EditRoute = ({route, open, setOpen}:
 
   return (
     <Popup open={open} onOpen={() => setOpen(true)} 
-      modal nested onClose={() => {
+      modal onClose={() => {
         setOpen(false); 
         resetStates();
       }}>
@@ -141,7 +141,8 @@ const EditRoute = ({route, open, setOpen}:
         }
         <HStack alignItems='center'space={1}width='100%'>
           <Text bold >Description: </Text>
-          <Input type='text' value={description} onChangeText={setDescription} width='75%' multiline />
+          <Input type='text' value={description} onChangeText={setDescription} width='75%' 
+            multiline numberOfLines={2} />
         </HStack>
         <HStack alignItems='center'space={1}width='100%'>
           <Text bold >Setter: </Text>

--- a/src/components/Route/RouteDetailsPanel.tsx
+++ b/src/components/Route/RouteDetailsPanel.tsx
@@ -1,12 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useQuery } from 'react-query';
 import { Box, Center, Text } from 'native-base';
-import placeholder_image from '../../placeholder_image.jpg';
 import { Route, Forum } from '../../xplat/types';
 import { buildRouteFetcher } from '../../utils/queries';
 
 const RouteDetailsPanel = ({ route, forumSetter }: { route: Route, forumSetter: (forum: Forum) => void }) => {
-  const { isLoading, isError, data } = useQuery(['route', { id: route.docRef!.id }], buildRouteFetcher(route));
+  const { isLoading, isError, data } = useQuery(['route', { id: route.getId() }], buildRouteFetcher(route));
 
   useEffect(() => {
     if (data !== undefined) {
@@ -39,6 +38,7 @@ const RouteDetailsPanel = ({ route, forumSetter }: { route: Route, forumSetter: 
       <Center>
         <Text fontSize={'2xl'} bold>{data.name}</Text>
         {data.image !== undefined && <img src={data.image} className='route-avatar' alt='route' />}
+        {data.description !== undefined && <Text>{data.description}</Text>}
         {data.setter !== undefined && <Text> Set by {data.setter.string}</Text>}
       </Center>
     </Box>

--- a/src/components/css/feed.css
+++ b/src/components/css/feed.css
@@ -48,10 +48,11 @@
     text-align: center;
     text-decoration: none;
     display: inline-block;
-    font-size: 15px;
+    font-size: 12pt;
     margin: 4px 2px;
     cursor: pointer;
     border-radius: 5px;
+    padding: 12px 10px;
 }
 
 .comment-panel {

--- a/src/components/css/feed.css
+++ b/src/components/css/feed.css
@@ -84,3 +84,12 @@
     margin-right: auto;
     border-radius: 6px;
 }
+
+.route-popup-avatar {
+    align-self: center;
+    margin-left: auto;
+    margin-right: auto;
+    max-height: 400px;
+    max-width: 80%;
+    border-radius: 5px;
+}

--- a/src/pages/RouteView.tsx
+++ b/src/pages/RouteView.tsx
@@ -8,6 +8,7 @@ import { queryClient } from '../App';
 import placeholder_image from '../placeholder_image.jpg';
 import { useContext } from 'react';
 import { AuthContext } from '../utils/AuthContext';
+import EditRoute from '../components/Route/EditRoute';
 
 const RouteView = () => {
   const [params] = useSearchParams();
@@ -110,6 +111,7 @@ const RouteView = () => {
                 null
               }
             </Flex>
+            <EditRoute route={data}/>
           </HStack>
         </Flex>
       </VStack>

--- a/src/pages/RouteView.tsx
+++ b/src/pages/RouteView.tsx
@@ -6,15 +6,16 @@ import { useQuery } from 'react-query';
 import { NaturalRules, Route, RouteStatus, UserStatus, invalidateDocRefId } from '../xplat/types';
 import { queryClient } from '../App';
 import placeholder_image from '../placeholder_image.jpg';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { AuthContext } from '../utils/AuthContext';
 import EditRoute from '../components/Route/EditRoute';
 
 const RouteView = () => {
   const [params] = useSearchParams();
+  const [showEditPopup, setShowEditPopup] = useState(false);
   const navigate = useNavigate();
   const authContext = useContext(AuthContext);
-
+  
   const hasRouteUID: boolean = params.has('uid');
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const routeUID: string = (hasRouteUID ? params.get('uid')! : '');
@@ -80,9 +81,15 @@ const RouteView = () => {
             </Button>
             {/* TODO: make a 'confirm archive?' popup */}
             {data.status === RouteStatus.Active ?
-              <Button onPress={archiveThisRoute}>
-                <Text variant='button'>Archive This Route</Text>
-              </Button>
+              <>
+                <Button onPress={archiveThisRoute}>
+                  <Text variant='button'>Archive This Route</Text>
+                </Button>
+                <Button onPress={() => setShowEditPopup(true)}>
+                  <Text variant='button'>Edit Route</Text>
+                  <EditRoute route={data} open={showEditPopup} setOpen={setShowEditPopup}/>
+                </Button>
+              </>
               :
               null
             }
@@ -111,7 +118,6 @@ const RouteView = () => {
                 null
               }
             </Flex>
-            <EditRoute route={data}/>
           </HStack>
         </Flex>
       </VStack>


### PR DESCRIPTION
# Describe your changes
Allows employees to update everything in a route other than the name, grade, and tags (since tags are currently unsupported). Once the update is made, it updates all queries relating to the specified route.
Here are some images of how the popup looks:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/31017536/224362092-66a46215-58b9-4952-8f86-d2f24e965ab4.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/31017536/224362185-317b7ff1-931b-4c40-8315-767d9965d7c5.png">
When the search component is finished this popup will use it to search for a user to set as the route setter.
# Issue ticket number and link
closes #78 