### PR TITLE
Search setters

### DIFF
--- a/src/components/Route/CreateRoute.tsx
+++ b/src/components/Route/CreateRoute.tsx
@@ -274,7 +274,10 @@ const CreateRoute = ({ refreshRoutes, isOpen, setIsOpen }: CreateRouteProps) => 
           }
           {
             overrideSetterBool == false && setter !== undefined &&
-            <AuthorHandle author={setter}/>
+            <HStack space={2}>
+              <Text>Selected: </Text>
+              <AuthorHandle author={setter}/>
+            </HStack>
           }
           <FormControl.Label>Description</FormControl.Label>
           <Input isRequired={false} type='text' onChangeText={setDescription}

--- a/src/components/Route/CreateRoute.tsx
+++ b/src/components/Route/CreateRoute.tsx
@@ -1,10 +1,11 @@
-import { Button, FormControl, Input, Text, VStack, Select, HStack } from 'native-base';
+import { Button, FormControl, Input, Text, VStack, Select, HStack, Radio } from 'native-base';
 import { useState } from 'react';
 import {
   convertCompetitionStringToClassifier, convertLeadclimbStringToClassifier,
-  convertTopropeStringToClassifier, convertTraverseStringToClassifier, createRoute
+  convertTopropeStringToClassifier, convertTraverseStringToClassifier, createRoute, getUserById
 } from '../../xplat/api';
 import Popup from 'reactjs-popup';
+import { SearchBox } from '../Search/SearchBox';
 import 'reactjs-popup/dist/index.css';
 import { User } from '../../xplat/types/user';
 import { compressImage } from '../../utils/CompressImage';
@@ -14,6 +15,8 @@ import {
   getAllCompRouteClassifiers, getAllRopeModifiers, convertBoulderStringToClassifier
 } from '../../xplat/api';
 import '../css/feed.css';
+import { SearchView } from '../Search/SearchBox';
+import AuthorHandle from '../User/AuthorHandle';
 
 const RouteTypeToGetAllClassifiers = (type: RouteType) => {
   if (type === RouteType.Boulder)
@@ -66,7 +69,7 @@ const CreateRoute = ({ refreshRoutes, isOpen, setIsOpen }: CreateRouteProps) => 
   const [thumbnailFile, setThumbnailFile] = useState<File>();
   const [imageCompressing, setImageCompressing] = useState<boolean>(false);
   const [setter, setSetter] = useState<User>();
-  const [overrideSetterBool, setOverrideSetterBool] = useState<boolean>(true);
+  const [overrideSetterBool, setOverrideSetterBool] = useState<boolean>(false);
   const [overrideSetterString, setOverrideSetterString] = useState<string>('');
   const [formError, setFormError] = useState(false);
 
@@ -244,12 +247,34 @@ const CreateRoute = ({ refreshRoutes, isOpen, setIsOpen }: CreateRouteProps) => 
               return <Select.Item key={rules} label={rules} value={rules} />;
             })}
           </Select>
+          <FormControl.Label>Setter type</FormControl.Label>
+          <Radio.Group name='Setter type' onChange={(val) => {
+            if (val == 'Text')
+            {
+              setSetter(undefined);
+            }
+            setOverrideSetterBool(val === 'Text');
+          }} defaultValue='User'>
+            <HStack space={2}>
+              <Radio value='User'>
+                User
+              </Radio>
+              <Radio value='Text'>
+                Custom
+              </Radio>
+            </HStack>
+          </Radio.Group>
           <FormControl.Label>Setter</FormControl.Label>
           {overrideSetterBool ?
             <Input isRequired={false} type='text' onChangeText={setOverrideSetterString}
               placeholder='Setter (optional)' />
             :
-            <Text>This will be a user search component</Text>
+            <SearchBox view={SearchView.Users} width='35%' maxHeight='100px' onSelect={
+              (userDocRef) => setSetter(getUserById(userDocRef))}/>
+          }
+          {
+            overrideSetterBool == false && setter !== undefined &&
+            <AuthorHandle author={setter}/>
           }
           <FormControl.Label>Description</FormControl.Label>
           <Input isRequired={false} type='text' onChangeText={setDescription}

--- a/src/components/Route/EditRoute.tsx
+++ b/src/components/Route/EditRoute.tsx
@@ -95,7 +95,7 @@ const EditRoute = ({route, open, setOpen}:
           </Text>
           {' ' + route.gradeDisplayString}
         </Text>
-        <Text>Route Thumbnail</Text>
+        <Text bold>Route Thumbnail</Text>
         { // show thumbnail stored in Firebase
           showStoredThumbnail ?
             <>
@@ -177,7 +177,10 @@ const EditRoute = ({route, open, setOpen}:
         }
         {
           setterType === 'User' && setter !== undefined && 
-          <AuthorHandle author={setter}/>
+          <HStack space={2}>
+            <Text>Selected: </Text>
+            <AuthorHandle author={setter}/>
+          </HStack>
         }
         <HStack alignItems='center'space={1} width='100%'>
           <Text bold >Natural Rules: </Text>

--- a/src/components/Route/EditRoute.tsx
+++ b/src/components/Route/EditRoute.tsx
@@ -2,10 +2,13 @@ import { RouteColor, User, NaturalRules, FetchedRoute, invalidateDocRefId } from
 import { Text, HStack, Input, VStack, Radio, Button, Select } from 'native-base';
 import {compressImage} from '../../utils/CompressImage';
 import Popup from 'reactjs-popup';
+import { SearchBox, SearchView } from '../Search/SearchBox';
 import 'reactjs-popup/dist/index.css';
 import '../css/feed.css';
 import { useState } from 'react';
 import { queryClient } from '../../App';
+import { getUserById } from '../../xplat/api';
+import AuthorHandle from '../User/AuthorHandle';
 
 const Ropes = [
   '1', '2', '3', '4', '5', '6', '7', '8', '9'
@@ -21,7 +24,7 @@ const EditRoute = ({route, open, setOpen}:
   const [thumbnailFile, setThumbnailFile] = useState<File | undefined>(undefined);
   const [color, setColor] = useState<string | undefined>(route.color);
   const [setterRawName, setSetterRawName] = useState<string | undefined>(route.setterRawName);
-  const [setterType, setSetterType] = useState<string>('User');
+  const [setterType, setSetterType] = useState<string>(route.setter === undefined ? 'Custom' : 'User');
   const [naturalRules, setNaturalRules] = useState<NaturalRules | undefined>(route.naturalRules);
   const [imageCompressing, setImageCompressing] = useState<boolean>(false);
 
@@ -34,7 +37,7 @@ const EditRoute = ({route, open, setOpen}:
     setThumbnailFile(undefined);
     setColor(route.color);
     setSetterRawName(route.setterRawName);
-    setSetterType('User');
+    setSetterType(route.setter === undefined ? 'Custom' : 'User');
     setNaturalRules(route.naturalRules);
   }
 
@@ -146,7 +149,13 @@ const EditRoute = ({route, open, setOpen}:
         </HStack>
         <HStack alignItems='center'space={1} width='100%'>
           <Text bold >Setter: </Text>
-          <Radio.Group name='Setter' defaultValue='User' onChange={(nextVal) => setSetterType(nextVal)}>
+          <Radio.Group name='Setter' defaultValue={setterType} onChange={
+            (nextVal) => {
+              if (nextVal == 'Custom')
+                setSetter(undefined);
+              setSetterType(nextVal);
+            }
+          }>
             <HStack alignItems='center'space={2}>
               <Radio value='User'>User</Radio>
               <Radio value='Custom'>Custom</Radio>
@@ -155,7 +164,8 @@ const EditRoute = ({route, open, setOpen}:
         </HStack>
         {
           setterType === 'User' ?
-            <Text>This will be a user search component</Text>
+            <SearchBox width='35%' view={SearchView.Users} maxHeight='100px' 
+              onSelect={(docRefID) => setSetter(getUserById(docRefID))}/>
             :
             <Input 
               type='text' 
@@ -164,6 +174,10 @@ const EditRoute = ({route, open, setOpen}:
               onChangeText={setSetterRawName} 
               width='50%' 
             />
+        }
+        {
+          setterType === 'User' && setter !== undefined && 
+          <AuthorHandle author={setter}/>
         }
         <HStack alignItems='center'space={1} width='100%'>
           <Text bold >Natural Rules: </Text>

--- a/src/components/Route/RouteDetailsPanel.tsx
+++ b/src/components/Route/RouteDetailsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useQuery } from 'react-query';
-import { Box, Center, Text } from 'native-base';
+import { Box, Center, Text, HStack } from 'native-base';
 import { Route, Forum } from '../../xplat/types';
 import { getForumById } from '../../xplat/api';
 import AuthorHandle from '../User/AuthorHandle';
@@ -41,7 +41,8 @@ const RouteDetailsPanel = ({ route, forumSetter }: { route: Route, forumSetter: 
         {data.thumbnailUrl !== undefined && <img src={data.thumbnailUrl} className='route-avatar' alt='route' />}
         {data.description !== undefined && <Text>{data.description}</Text>}
         {data.setterRawName !== undefined && <Text> Set by {data.setterRawName}</Text>}
-        {data.setter !== undefined && <AuthorHandle author={data.setter}/>}
+        {data.setter !== undefined && 
+        <HStack alignItems='center' space={1}><Text>Set by:</Text> <AuthorHandle author={data.setter}/></HStack>}
       </Center>
     </Box>
   );

--- a/src/components/Route/RouteDetailsPanel.tsx
+++ b/src/components/Route/RouteDetailsPanel.tsx
@@ -2,14 +2,15 @@ import { useEffect } from 'react';
 import { useQuery } from 'react-query';
 import { Box, Center, Text } from 'native-base';
 import { Route, Forum } from '../../xplat/types';
-import { buildRouteFetcher } from '../../utils/queries';
+import { getForumById } from '../../xplat/api';
+import AuthorHandle from '../User/AuthorHandle';
 
 const RouteDetailsPanel = ({ route, forumSetter }: { route: Route, forumSetter: (forum: Forum) => void }) => {
-  const { isLoading, isError, data } = useQuery(['route', { id: route.getId() }], buildRouteFetcher(route));
+  const { isLoading, isError, data } = useQuery(['route', { id: route.getId() }], route.buildFetcher());
 
   useEffect(() => {
     if (data !== undefined) {
-      forumSetter(data.forum);
+      forumSetter(getForumById(data.forumDocRefID));
     }
   }, [data]);
 
@@ -37,9 +38,10 @@ const RouteDetailsPanel = ({ route, forumSetter }: { route: Route, forumSetter: 
     <Box flexDir={'column'} width={'25%'} top={'100px'} position='fixed'>
       <Center>
         <Text fontSize={'2xl'} bold>{data.name}</Text>
-        {data.image !== undefined && <img src={data.image} className='route-avatar' alt='route' />}
+        {data.thumbnailUrl !== undefined && <img src={data.thumbnailUrl} className='route-avatar' alt='route' />}
         {data.description !== undefined && <Text>{data.description}</Text>}
-        {data.setter !== undefined && <Text> Set by {data.setter.string}</Text>}
+        {data.setterRawName !== undefined && <Text> Set by {data.setterRawName}</Text>}
+        {data.setter !== undefined && <AuthorHandle author={data.setter}/>}
       </Center>
     </Box>
   );

--- a/src/pages/RouteView.tsx
+++ b/src/pages/RouteView.tsx
@@ -121,10 +121,10 @@ const RouteView = () => {
                 data.setter === undefined ?
                   <Text><Text bold>Setter: </Text>{data.setterRawName ?? notAssigned}</Text>
                   :
-                  <Text alignSelf='center'>
+                  <HStack alignItems='center'>
                     <Text bold alignSelf='center'>Setter: </Text> 
                     <AuthorHandle author={data.setter}/>
-                  </Text>
+                  </HStack>
               }
               <Text><Text bold>Date Set: </Text>{data.timestamp?.toLocaleDateString() ?? notAssigned}</Text>
               <Text><Text bold>Sends: </Text>{data.numSends}</Text>

--- a/src/pages/RouteView.tsx
+++ b/src/pages/RouteView.tsx
@@ -9,6 +9,7 @@ import { useContext, useState } from 'react';
 import { AuthContext } from '../utils/AuthContext';
 import { ConfirmationPopup } from '../components/ConfirmationPopup';
 import EditRoute from '../components/Route/EditRoute';
+import AuthorHandle from '../components/User/AuthorHandle';
 
 const RouteView = () => {
   const [params] = useSearchParams();
@@ -116,7 +117,15 @@ const RouteView = () => {
                 data.stringifiedTags === '' ? notAssigned : data.stringifiedTags
               }</Text>
               <Text><Text bold>Rope: </Text>{data.rope ?? notAssigned}</Text>
-              <Text><Text bold>Setter: </Text>{data.setterRawName ?? notAssigned}</Text>
+              {
+                data.setter === undefined ?
+                  <Text><Text bold>Setter: </Text>{data.setterRawName ?? notAssigned}</Text>
+                  :
+                  <Text alignSelf='center'>
+                    <Text bold alignSelf='center'>Setter: </Text> 
+                    <AuthorHandle author={data.setter}/>
+                  </Text>
+              }
               <Text><Text bold>Date Set: </Text>{data.timestamp?.toLocaleDateString() ?? notAssigned}</Text>
               <Text><Text bold>Sends: </Text>{data.numSends}</Text>
               <Text><Text bold>Likes: </Text>{data.likes.length}</Text>


### PR DESCRIPTION
# Describe your changes
Adds search option in `CreateRoute` and `EditRoute` popups, along with adding the `AuthorHandle` to the `RouteView` and `RouteFeed` pages when the setter is a `User`.

RouteView:
![image](https://user-images.githubusercontent.com/31017536/229558870-d1689b00-fac7-42c0-a837-92f65e5d5450.png)
EditRoute:
![image](https://user-images.githubusercontent.com/31017536/229558059-080f799f-c12b-4314-8469-36acfa70d2f3.png)
CreateRoute:
![image](https://user-images.githubusercontent.com/31017536/229558174-15fcad08-ecb2-4700-8b73-54b791d03829.png)
RouteFeed:
![image](https://user-images.githubusercontent.com/31017536/229558946-80aa6b81-2ac6-43cc-8199-a996d8fa5947.png)

# Issue ticket number and link
closes #108 