### PR TITLE
Fix/modactionpanel/width

### DIFF
--- a/src/components/css/ReportCard.css
+++ b/src/components/css/ReportCard.css
@@ -15,7 +15,7 @@
 }
 
 .modaction-panel {
-  width: 90%;
+  width: 100%;
   height: inherit;
   overflow-y: scroll;
   overflow-x: hidden;

--- a/src/components/css/ReportCard.css
+++ b/src/components/css/ReportCard.css
@@ -15,7 +15,7 @@
 }
 
 .modaction-panel {
-  width: 100%;
+  width: 90%;
   height: inherit;
   overflow-y: scroll;
   overflow-x: hidden;

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -131,6 +131,7 @@ const Reports = () => {
                   return <ModCollectionCard data={item} />;
                 }}
                 keyExtractor={(item, index) => index.toString()}
+                p='2'
               />
             </div>
           </div>


### PR DESCRIPTION
# Describe your changes
Quick fix that fixes the padding for the Mod Action History panel. Prior to this the panel would be clipped on the right side by the divider when viewed on my laptop.
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/31017536/232592447-170e4514-8445-4339-972c-e93b475b3355.png">

# Issue ticket number and link