### PR TITLE
Fix/text input

### DIFF
--- a/src/components/Route/CreateRoute.tsx
+++ b/src/components/Route/CreateRoute.tsx
@@ -1,4 +1,4 @@
-import { Button, FormControl, Input, Text, VStack, Select, HStack, Radio } from 'native-base';
+import { Button, FormControl, Text, VStack, Select, HStack, Radio } from 'native-base';
 import { useState } from 'react';
 import {
   convertCompetitionStringToClassifier, convertLeadclimbStringToClassifier,
@@ -17,6 +17,7 @@ import {
 import '../css/feed.css';
 import { SearchView } from '../Search/SearchBox';
 import AuthorHandle from '../User/AuthorHandle';
+import TextInput from '../common/TextInput';
 
 const RouteTypeToGetAllClassifiers = (type: RouteType) => {
   if (type === RouteType.Boulder)
@@ -150,7 +151,7 @@ const CreateRoute = ({ refreshRoutes, isOpen, setIsOpen }: CreateRouteProps) => 
         <VStack space={1} overflowY='scroll' maxH='90vh'>
           <Text fontSize='lg' alignSelf='center'>Create a new Route</Text>
           <FormControl.Label isRequired>Route Name</FormControl.Label>
-          <Input isRequired type='text' onChangeText={setName} placeholder='Name' />
+          <TextInput defaultValue='' onChangeText={setName} placeholder='Name'/>
           <FormControl.Label>Route Thumbnail</FormControl.Label>
           { // if thumbnailFile is undefined, show select file input
             thumbnailFile === undefined ?
@@ -266,7 +267,7 @@ const CreateRoute = ({ refreshRoutes, isOpen, setIsOpen }: CreateRouteProps) => 
           </Radio.Group>
           <FormControl.Label>Setter</FormControl.Label>
           {overrideSetterBool ?
-            <Input isRequired={false} type='text' onChangeText={setOverrideSetterString}
+            <TextInput defaultValue='' onChangeText={setOverrideSetterString}
               placeholder='Setter (optional)' />
             :
             <SearchBox view={SearchView.Users} width='35%' maxHeight='100px' onSelect={
@@ -280,7 +281,7 @@ const CreateRoute = ({ refreshRoutes, isOpen, setIsOpen }: CreateRouteProps) => 
             </HStack>
           }
           <FormControl.Label>Description</FormControl.Label>
-          <Input isRequired={false} type='text' onChangeText={setDescription}
+          <TextInput defaultValue=''  onChangeText={setDescription}
             placeholder='Description (optional)' />
           {formError &&
             <FormControl.ErrorMessage alignSelf='center'>

--- a/src/components/Route/EditRoute.tsx
+++ b/src/components/Route/EditRoute.tsx
@@ -1,5 +1,5 @@
 import { RouteColor, User, NaturalRules, FetchedRoute, invalidateDocRefId } from '../../xplat/types';
-import { Text, HStack, Input, VStack, Radio, Button, Select } from 'native-base';
+import { Text, HStack,  VStack, Radio, Button, Select } from 'native-base';
 import {compressImage} from '../../utils/CompressImage';
 import Popup from 'reactjs-popup';
 import { SearchBox, SearchView } from '../Search/SearchBox';
@@ -9,6 +9,7 @@ import { useState } from 'react';
 import { queryClient } from '../../App';
 import { getUserById } from '../../xplat/api';
 import AuthorHandle from '../User/AuthorHandle';
+import TextInput from '../common/TextInput';
 
 const Ropes = [
   '1', '2', '3', '4', '5', '6', '7', '8', '9'
@@ -144,8 +145,8 @@ const EditRoute = ({route, open, setOpen}:
         }
         <HStack alignItems='center'space={1} width='100%'>
           <Text bold >Description: </Text>
-          <Input type='text' value={description} onChangeText={setDescription} width='75%' 
-            multiline numberOfLines={2} />
+          <TextInput value={description} onChangeText={setDescription} width='75%' 
+            multiline={true}/>
         </HStack>
         <HStack alignItems='center'space={1} width='100%'>
           <Text bold >Setter: </Text>
@@ -167,8 +168,7 @@ const EditRoute = ({route, open, setOpen}:
             <SearchBox width='35%' view={SearchView.Users} maxHeight='100px' 
               onSelect={(docRefID) => setSetter(getUserById(docRefID))}/>
             :
-            <Input 
-              type='text' 
+            <TextInput 
               value={setterRawName} 
               placeholder='Non-user setter' 
               onChangeText={setSetterRawName} 

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import './textinput.css';
+const TextInput = 
+  ({
+    defaultValue, placeholder, value, onChangeText, multiline, password, width, padding, margin
+  }: 
+    {
+      defaultValue?: string, placeholder?: string, value?: string, onChangeText?: (arg0: string) => void, 
+      multiline?: boolean, password?: boolean, width?: string, padding?: string, margin?: string, 
+    }) => {
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => 
+    {
+      if (onChangeText === undefined)
+        return;
+      onChangeText(event.target.value);
+    };
+
+    if (multiline)
+    {
+      return (
+        <textarea style={{width: width || 'auto', margin: margin || 'auto'}}
+          className='native-base-clone-input' value={value} onChange={handleChange}/>
+      );
+    }
+
+    return (
+      <input style={{padding: padding || 'auto', margin: margin || 'auto'}}
+        className='native-base-clone-input' type={password ? 'password' : 'text'} value={value}
+        defaultValue={defaultValue} onChange={handleChange} width={width || 'auto'} placeholder={placeholder}/>
+    );
+  };
+
+export default TextInput;

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -18,8 +18,8 @@ const TextInput =
     if (multiline)
     {
       return (
-        <textarea style={{width: width || 'auto', margin: margin || 'auto'}}
-          className='native-base-clone-input' defaultValue={defaultValue} value={value} onChange={handleChange}/>
+        <textarea style={{width: width || 'auto', margin: margin || 'auto'}} className='native-base-clone-input' 
+          defaultValue={defaultValue} placeholder={placeholder} value={value} onChange={handleChange}/>
       );
     }
 

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -19,7 +19,7 @@ const TextInput =
     {
       return (
         <textarea style={{width: width || 'auto', margin: margin || 'auto'}}
-          className='native-base-clone-input' value={value} onChange={handleChange}/>
+          className='native-base-clone-input' defaultValue={defaultValue} value={value} onChange={handleChange}/>
       );
     }
 

--- a/src/components/common/textinput.css
+++ b/src/components/common/textinput.css
@@ -1,0 +1,16 @@
+.native-base-clone-input {
+  padding: 10px 5px;
+  border: 1px solid #d4d4d4;
+  border-radius: 5px;
+  font-family: sans-serif;
+}
+
+.native-base-clone-input:hover {
+  border-color: #0b91b1;
+}
+
+.native-base-clone-input:focus {
+  outline: none !important;
+  background-color: #eaf4f7;
+  border: 2px solid #0a91b1;
+}


### PR DESCRIPTION
# Describe your changes
Creates new component called `TextInput` and implements it on the `CreateRoute` and `EditRoute` popup. I decided against adding this to other areas since I wasn't able to replicate the bug anywhere else outside of popups. If it ain't broke don't fix it 😄 .
This component mimics the functionality and aesthetics of the native-base `Input` component. The list of supported props are below (all are optional):

- `width, padding, margin: string` (self explanatory)
- `defaultValue: string`
- `placeholder: string` (light gray text shown when nothing is in component)
- `onChangeText: (string) => void` (setter for the input text)
- `multiline: boolean` (if true, changes from <input> to <textarea> which allows the user to resize the box as they need)
- `password: boolean` (sets type to `password` if prop is true)

An example of the component with `multiline = {true}`:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/31017536/232638720-f3442a46-757b-42c1-91ac-0374ae56d6a6.png">

# Issue ticket number and link
closes #118 