### PR TITLE
improve consistency & visibility of colors on Reports page

### DIFF
--- a/src/components/Reports/ReportCard.tsx
+++ b/src/components/Reports/ReportCard.tsx
@@ -108,7 +108,7 @@ const ReportCard = ({
             setModerationAction(ModerationAction.Delete);
             setConfirmationOpen(true);
           }}
-          background='red.400'
+          background='red.500'
         >
           <Text variant='button'>Delete</Text>
         </Button>
@@ -117,7 +117,7 @@ const ReportCard = ({
             setModerationAction(ModerationAction.Ban);
             setConfirmationOpen(true);
           }}
-          background='red.400'
+          background='red.500'
         >
           <Text variant='button'>Ban</Text>
         </Button>

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -143,7 +143,7 @@ const Reports = () => {
               <Text alignSelf='center' variant='header'>
                 No reported content.
               </Text>
-              <Button onPress={() => reports.refetch()}>
+              <Button alignSelf='center' onPress={() => reports.refetch()}>
                 <Text variant='button'>Refresh</Text>
               </Button>
             </Box>
@@ -153,7 +153,7 @@ const Reports = () => {
               data={Array.from(reportedContent)}
               renderItem={({ item, index }) => (
                 <Box
-                  bg={index % 2 == 0 ? 'red.500' : 'red.400'}
+                  bg='red.300'
                   rounded='md'
                   marginY={1}
                   p={1}


### PR DESCRIPTION
# Describe your changes
**changed from** 
![image](https://user-images.githubusercontent.com/73561858/232911563-4825c893-1c1f-4549-9490-652cdc0a5f34.png)
alternating colors of report cards had issues with button color ^ 


**to** 
![image](https://user-images.githubusercontent.com/73561858/232911580-b4934fb5-a162-4121-8494-f3fe9fb87f3b.png)

I tried making absolve green as well as changing the background for the card to blue to match FAQ & Tutorial, but those didn't look right.

# Issue ticket number and link
NA