### PR TITLE
More improvements to Reports page UI

### DIFF
--- a/src/components/Reports/ModAction/ModActionCard.tsx
+++ b/src/components/Reports/ModAction/ModActionCard.tsx
@@ -36,13 +36,11 @@ const ModActionCard = ({
 
   return (
     <Box
-      bg='secondary.300'
+      bg='primary.300'
       rounded='md'
       m='1'
       p='1'
       zIndex={0}
-      borderColor='secondary.400'
-      borderWidth={2}
     >
       <Text variant='header' bold>
         {data.timestamp.toLocaleTimeString()}

--- a/src/components/Reports/ModAction/ModCollectionCard.tsx
+++ b/src/components/Reports/ModAction/ModCollectionCard.tsx
@@ -9,12 +9,12 @@ const ModCollectionCard = ({data}: {data: ModActionCollection}) => {
   return (
     <>
       <Pressable
-        bg='secondary.300'
+        bg='primary.300'
         rounded='md'
         m='1'
         p='1'
         zIndex={0}
-        borderColor='secondary.400'
+        borderColor='primary.400'
         borderWidth={2}
         onPress={() => setExpanded(!expanded)}
       >
@@ -26,8 +26,8 @@ const ModCollectionCard = ({data}: {data: ModActionCollection}) => {
         </HStack>
       </Pressable>
       {expanded ? (
-        <Box bg='secondary.200' 
-          rounded='md' m='1' marginLeft='3' p='1' zIndex={0} borderColor='secondary.400' borderWidth={2}>
+        <Box bg='primary.200' 
+          rounded='md' m='1' marginLeft='8' p='2' zIndex={0} borderColor='primary.400' borderWidth={2}>
           {data.modActions.map((action, index) => {
             return <ModActionCard action={action} index={index} key={index.toString()}/>;
           }

--- a/src/components/Reports/ReportCard.tsx
+++ b/src/components/Reports/ReportCard.tsx
@@ -77,8 +77,8 @@ const ReportCard = ({
         />
       )}
       {contentjsx}
-      <ArrowForwardIcon size='lg' alignSelf='center' color='white' />
-      <Text variant='body' alignSelf='center' color='white'>
+      <ArrowForwardIcon size='lg' alignSelf='center' color='black' />
+      <Text variant='body' alignSelf='center' color='black'>
         This was reported by{' '}
         <Popup
           position='bottom center'

--- a/src/components/css/ReportCard.css
+++ b/src/components/css/ReportCard.css
@@ -1,6 +1,6 @@
 .reporter-handle {
   text-decoration: underline;
-  color: white;
+  color: black;
 }
 
 .reporter-handle:hover {


### PR DESCRIPTION
# Describe your changes
another set of improvements for the Reports page:

- black text on report cards for readability
- modAction cards within our color scheme instead of pink which wasn't used elsewhere
- modAction cards have more padding & left margin when expanded, will look good when we have more modAction cards

![image](https://user-images.githubusercontent.com/73561858/232914818-fb603826-843b-498b-9b75-8ef56fef6551.png)

# Issue ticket number and link